### PR TITLE
[Docs] Use Distributions.LogLogistic to fix ambiguity in docs build

### DIFF
--- a/docs/src/parametric/generalhazard.md
+++ b/docs/src/parametric/generalhazard.md
@@ -37,7 +37,7 @@ hazard_cumhazard_plot(LogNormal(0.5, 1), "LogNormal")
 ### LogLogistic
 
 ```@example 1
-hazard_cumhazard_plot(LogLogistic(1, 0.5), "LogLogistic")
+hazard_cumhazard_plot(Distributions.LogLogistic(1, 0.5), "LogLogistic")
 ```
 
 ### Weibull


### PR DESCRIPTION
## Summary
- The `@example` block in `docs/src/parametric/generalhazard.md` calls `LogLogistic(1, 0.5)`, but both `Distributions` and `SurvivalDistributions` export `LogLogistic`, so it resolves to neither and the docs build fails with `UndefVarError`.
- Qualifies the call as `Distributions.LogLogistic` to resolve the ambiguity.

## Test plan
- [x] `julia --project=docs docs/make.jl` builds without the `UndefVarError` (previously failed at `parametric/generalhazard.md:39-41`).
- [x] `doctest(SurvivalModels)` still passes (1/1).