### PR TITLE
[Cox] Fix predict_expected/predict_survival; add time-indexed prediction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SurvivalModels"
 uuid = "230d35e3-bb2c-48f4-adfc-0b42c4b39395"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Oskar Laverny <oskar.laverny@univ-amu.fr> and contributors"]
 
 [deps]

--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -272,6 +272,14 @@ predict(model, :survival, ts)
 
 Passing a time argument with `:lp`, `:risk`, or `:terms` is an error — those types do not depend on time.
 
+```@docs
+SurvivalModels.predict_expected
+```
+
+```@docs
+SurvivalModels.predict_survival
+```
+
 ### Example: Prediction on New Data
 
 The following example is drawn from [this article](https://missingdatasolutions.rbind.io/2022/12/cox-baseline-hazard/). 

--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -246,21 +246,31 @@ summary(::SurvivalModels.Cox)
 After fitting a Cox model, you can obtain various types of predictions using the `predict` function:
 
 ```julia
-predict(model; type=:lp)        # Linear predictor (default)
-predict(model; type=:risk)      # Relative risk (exp(linear predictor))
-predict(model; type=:expected)  # Expected cumulative hazard
-predict(model; type=:survival)  # Survival probability
-predict(model; type=:terms)     # Contribution of each term (covariate) to the linear predictor
+predict(model, :lp)              # Linear predictor (default)
+predict(model, :risk)            # Relative risk (exp(linear predictor))
+predict(model, :expected)        # Cumulative hazard at each subject's own time Tᵢ
+predict(model, :survival)        # Survival probability at each subject's own time Tᵢ
+predict(model, :terms)           # Contribution of each term to the linear predictor
+
+predict(model, :expected, t)     # Cumulative hazard for every subject at scalar time t
+predict(model, :survival, t)
+predict(model, :expected, ts)    # Matrix (n × length(ts)) over a vector of times
+predict(model, :survival, ts)
 ```
 
 **Available types:**
 - `:lp` — Linear predictor (Xβ)
 - `:risk` — Relative risk, exp(Xβ)
-- `:expected` — Expected cumulative hazard for each subject
-- `:survival` — Survival probability for each subject
+- `:expected` — Expected cumulative hazard
+- `:survival` — Survival probability
 - `:terms` — Covariate-wise contributions to the linear predictor
 
-If you want to center predictions (e.g., for survival curves), you can use the `centered` keyword argument.
+**Output shapes for `:expected` and `:survival`:**
+- No time argument → length-`n` vector, with each subject evaluated at their own observed time `Tᵢ`. This matches R's `predict(coxph, type="expected")` / `type="survival"` convention.
+- `t::Real` → length-`n` vector at the scalar time.
+- `ts::AbstractVector` → `n × length(ts)` matrix.
+
+Passing a time argument with `:lp`, `:risk`, or `:terms` is an error — those types do not depend on time.
 
 ### Example: Prediction on New Data
 
@@ -302,6 +312,15 @@ And then each of the prediction type can be accessed as follows:
 ```
 ```@example 5
     predict(model, :survival)
+```
+
+Evaluate at arbitrary times:
+
+```@example 5
+    predict(model, :survival, 5.0)
+```
+```@example 5
+    predict(model, :survival, [1.0, 5.0, 10.0])
 ```
 
 

--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -184,22 +184,16 @@ function predict_terms(C::Cox, og=true)
 end
 predict_risk(C::Cox; type = :risk) = exp.(predict_lp(C))
 
-"""
-    _cumhaz_at(Λ0, t_grid, t)
-
-Step-interpolate the Breslow cumulative baseline hazard `Λ0` (sampled at the sorted
-ascending grid `t_grid`) onto an arbitrary time `t`. Cumulative hazard is right-continuous
-with left limits: returns `0` for `t < t_grid[1]` and `Λ0[end]` for `t ≥ t_grid[end]`.
-"""
+# Step-interpolate the Breslow cumulative baseline hazard `Λ0` (sampled at the sorted
+# ascending grid `t_grid`) onto an arbitrary time `t`. Cumulative hazard is right-continuous
+# with left limits: returns `0` for `t < t_grid[1]` and `Λ0[end]` for `t ≥ t_grid[end]`.
 function _cumhaz_at(Λ0::AbstractVector, t_grid::AbstractVector, t::Real)
     idx = searchsortedlast(t_grid, t)
     return idx == 0 ? zero(eltype(Λ0)) : Λ0[idx]
 end
 
-"""
-Internal: returns an `n × length(times)` matrix of cumulative hazards
-`Λᵢ(t) = Λ₀(t) · exp(ηᵢ)` for every subject `i` and every requested time.
-"""
+# Internal: returns an `n × length(times)` matrix of cumulative hazards
+# `Λᵢ(t) = Λ₀(t) · exp(ηᵢ)` for every subject `i` and every requested time.
 function _predict_expected_at(C::Cox, times::AbstractVector)
     Λ0 = baseline_hazard(C, centered=true)
     t_grid = sort(unique(C.M.T))

--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -93,6 +93,7 @@ nobs(M::CoxMethod) = size(getX(M),1) # Default to X being (n,m)
 nvar(M::CoxMethod) = size(getX(M),2)
 get_perm(M::CoxMethod) = M.o
 get_og_X(M::CoxMethod) = getX(M)[sortperm(get_perm(M)), :]
+get_og_T(M::CoxMethod) = M.T[sortperm(get_perm(M))]
 
 # Extract the hessian: 
 function get_hessian(M::CoxMethod, β)
@@ -181,9 +182,79 @@ function predict_terms(C::Cox, og=true)
     end
     return rez
 end
-predict_expected(C::Cox) = baseline_hazard(C, centered=true) .* exp.(predict_lp(C))
-predict_survival(C::Cox) = exp.(-predict_expected(C))
 predict_risk(C::Cox; type = :risk) = exp.(predict_lp(C))
+
+"""
+    _cumhaz_at(Λ0, t_grid, t)
+
+Step-interpolate the Breslow cumulative baseline hazard `Λ0` (sampled at the sorted
+ascending grid `t_grid`) onto an arbitrary time `t`. Cumulative hazard is right-continuous
+with left limits: returns `0` for `t < t_grid[1]` and `Λ0[end]` for `t ≥ t_grid[end]`.
+"""
+function _cumhaz_at(Λ0::AbstractVector, t_grid::AbstractVector, t::Real)
+    idx = searchsortedlast(t_grid, t)
+    return idx == 0 ? zero(eltype(Λ0)) : Λ0[idx]
+end
+
+"""
+Internal: returns an `n × length(times)` matrix of cumulative hazards
+`Λᵢ(t) = Λ₀(t) · exp(ηᵢ)` for every subject `i` and every requested time.
+"""
+function _predict_expected_at(C::Cox, times::AbstractVector)
+    Λ0 = baseline_hazard(C, centered=true)
+    t_grid = sort(unique(C.M.T))
+    η = exp.(predict_lp(C))
+    n, m = length(η), length(times)
+    out = Matrix{Float64}(undef, n, m)
+    @inbounds for j in 1:m
+        Λ_j = _cumhaz_at(Λ0, t_grid, times[j])
+        for i in 1:n
+            out[i, j] = Λ_j * η[i]
+        end
+    end
+    return out
+end
+
+"""
+    predict_expected(C::Cox)
+    predict_expected(C::Cox, t::Real)
+    predict_expected(C::Cox, ts::AbstractVector)
+
+Cumulative hazard `Λᵢ(t) = Λ₀(t) · exp(ηᵢ)` per subject, where `Λ₀` is the Breslow
+estimator centered to the fit's reference (continuous covariates at their mean,
+categorical at their mode) and `ηᵢ = (Xᵢ - X̄) β`.
+
+Output shape:
+- no time argument → length-`n` vector with each subject evaluated at their own
+  observed time `Tᵢ` (the convention used by R's `predict(coxph, type="expected")`);
+- `t::Real` → length-`n` vector at the scalar time;
+- `ts::AbstractVector` → `n × length(ts)` matrix.
+"""
+function predict_expected(C::Cox)
+    Λ0 = baseline_hazard(C, centered=true)
+    t_grid = sort(unique(C.M.T))
+    η = exp.(predict_lp(C))             # original data order
+    T_og = get_og_T(C.M)                # original data order
+    return [_cumhaz_at(Λ0, t_grid, T_og[i]) * η[i] for i in eachindex(η)]
+end
+predict_expected(C::Cox, t::Real)           = vec(_predict_expected_at(C, [t]))
+predict_expected(C::Cox, ts::AbstractVector) = _predict_expected_at(C, ts)
+
+"""
+    predict_survival(C::Cox)
+    predict_survival(C::Cox, t::Real)
+    predict_survival(C::Cox, ts::AbstractVector)
+
+Per-subject survival probability `Sᵢ(t) = exp(-Λᵢ(t))` derived from
+[`predict_expected`](@ref). Shapes match `predict_expected`: the no-argument form
+returns a length-`n` vector with each subject at their own observed time `Tᵢ`;
+the `t::Real` form is a length-`n` vector at a scalar time; the `ts::AbstractVector`
+form is an `n × length(ts)` matrix.
+"""
+predict_survival(C::Cox)                     = exp.(-predict_expected(C))
+predict_survival(C::Cox, t::Real)            = exp.(-predict_expected(C, t))
+predict_survival(C::Cox, ts::AbstractVector) = exp.(-predict_expected(C, ts))
+
 function StatsBase.predict(C::Cox, type::Symbol=:lp)
     type==:lp && return predict_lp(C)
     type==:risk && return predict_risk(C)
@@ -191,6 +262,18 @@ function StatsBase.predict(C::Cox, type::Symbol=:lp)
     type==:terms && return predict_terms(C)
     type==:survival && return predict_survival(C)
     error("The prediction you want was not understood. Please pass a `type` parameter among (:lp, :risk, :expected, :terms, :survival). See `?Cox` for details.")
+end
+
+function StatsBase.predict(C::Cox, type::Symbol, t::Real)
+    type==:expected && return predict_expected(C, t)
+    type==:survival && return predict_survival(C, t)
+    error("Time-indexed `predict` only supports `:expected` and `:survival`, got `:$type`.")
+end
+
+function StatsBase.predict(C::Cox, type::Symbol, ts::AbstractVector)
+    type==:expected && return predict_expected(C, ts)
+    type==:survival && return predict_survival(C, ts)
+    error("Time-indexed `predict` only supports `:expected` and `:survival`, got `:$type`.")
 end
 
 function StatsBase.fit(::Type{T}, formula::FormulaTerm, df::DataFrame) where T<:Union{CoxMethod,Cox}

--- a/test/test.jl
+++ b/test/test.jl
@@ -135,16 +135,62 @@ end
                                         -8.6357545  0.000000
                                         -11.1710219  0.000000] rtol=1e-2
 
-        # These two broken tests corresponds to values really outputted by R. 
-        @test_broken predict(model, :expected) ≈ [0.9385114, 0.6811525, 0.9959573, 0.3843788, 0.3230369, 0.6475801, 0.9538031, 1.0755799] rtol=1e-2
-        @test_broken predict(model, :survival) ≈ [0.3912098, 0.5060335, 0.3693697, 0.6808734, 0.7239472, 0.5233106, 0.3852730, 0.3410999] rtol=1e-2
+        # The no-arg form evaluates each subject at its own observed time Tᵢ — matches
+        # R's `predict(coxph, type="expected")` / `type="survival"` convention.
+        @test predict(model, :expected) ≈ [0.9385114, 0.6811525, 0.9959573, 0.3843788, 0.3230369, 0.6475801, 0.9538031, 1.0755799] rtol=1e-2
+        @test predict(model, :survival) ≈ [0.3912098, 0.5060335, 0.3693697, 0.6808734, 0.7239472, 0.5233106, 0.3852730, 0.3410999] rtol=1e-2
 
-        # While these two working ones corresponds to the explanations that are on the website: 
-        @test predict(model, :expected) ≈ [0.93851138, 0.68115250, 0.05397488, 0.02221579, 103.13326837, 0.64758014, 0.95380312, 1.07557986] rtol=1e-2
-        @test predict(model, :survival) ≈ [3.912098e-01, 5.060335e-01, 9.474559e-01, 9.780292e-01, 1.621028e-45, 5.233106e-01, 3.852730e-01, 3.410999e-01] rtol=1e-2
+    end
+end
 
-        # Which ones hsould we keep ? can we reproduce (with e.g. another symbol like :expected2 and :survival2) the number given by R ? 
 
+@testitem "Cox predict at arbitrary times" begin
+    using DataFrames
+    using SurvivalModels: baseline_hazard, predict, CoxNM, CoxOptim, CoxHessian, CoxDefault, CoxApprox
+
+    # Same fixture as the baseline-hazard testitem above
+    time   = [1.0, 3.0, 5.0, 6.0, 2.0, 7.0, 9.0, 11.0]
+    status = [true, false, true, true, true, false, true, true]
+    sex    = Symbol.([1, 1, 1, 1, 0, 0, 0, 0])
+    age    = [57, 52, 48, 42, 39, 31, 26, 22]
+    df     = DataFrame(time = time, status = status, sex = sex, age = age)
+    f      = @formula(Surv(time, status) ~ age + sex)
+    n      = length(time)
+
+    for M in (CoxNM, CoxOptim, CoxHessian, CoxDefault, CoxApprox)
+        model = fit(M, f, df)
+
+        # Scalar t: length-n vector
+        @test size(predict(model, :expected, 5.0))  == (n,)
+        @test size(predict(model, :survival, 5.0))  == (n,)
+
+        # Vector ts: n × length(ts) matrix
+        ts = [1.0, 5.0, 10.0]
+        @test size(predict(model, :expected, ts))   == (n, length(ts))
+        @test size(predict(model, :survival, ts))   == (n, length(ts))
+
+        # Self-consistency: the no-arg form equals predict(:expected, Tᵢ) at each subject
+        no_arg = predict(model, :expected)
+        for i in 1:n
+            @test no_arg[i] ≈ predict(model, :expected, time[i])[i] rtol=1e-10
+        end
+
+        # Survival probabilities are in [0, 1] and monotone non-increasing in t
+        S = predict(model, :survival, [0.1, 0.5, 1.0, 2.0, 5.0, 10.0])
+        @test all(0 .≤ S .≤ 1 .+ 1e-12)
+        @test all(diff(S, dims = 2) .≤ 1e-12)
+
+        # S(t < min(T)) ≈ 1; S(t = 0) ≈ 1
+        @test predict(model, :survival, 0.0)    ≈ ones(n) atol=1e-10
+        @test predict(model, :survival, 1e-6)   ≈ ones(n) atol=1e-10
+
+        # Beyond max(T) plateaus at S(max(T))
+        @test predict(model, :survival, 1e6)    ≈ predict(model, :survival, maximum(time)) rtol=1e-10
+
+        # Misuse on a non-time-indexed prediction type errors loudly
+        @test_throws ErrorException predict(model, :lp,    5.0)
+        @test_throws ErrorException predict(model, :risk,  5.0)
+        @test_throws ErrorException predict(model, :terms, 5.0)
     end
 end
 


### PR DESCRIPTION
The previous implementations multiplied `baseline_hazard(C, centered=true)` (length = number of unique event times) by `exp.(predict_lp(C))` (length n) elementwise. The broadcast was either a runtime DimensionMismatch (whenever ties existed) or a meaningless pairing of the i-th sorted unique event time with the i-th subject. The test file already noted this with `@test_broken` on the R-matching values.

Replace the broken implementation with three signatures:

  predict_expected(C)        -> length-n vector, each subject at their own Tᵢ
  predict_expected(C, t)     -> length-n vector at scalar t
  predict_expected(C, ts)    -> n × length(ts) matrix

Same shapes for predict_survival. The no-arg behaviour matches R's predict(coxph, type="expected") / type="survival" convention. Time-indexed prediction is now possible at arbitrary user times via step-interpolation of the Breslow estimator.

Implementation details:
- New helper `_cumhaz_at(Λ0, t_grid, t)` for step-interpolated cumhazard.
- New internal `_predict_expected_at(C, times)` returning the n × m matrix.
- New `get_og_T(M)` accessor mirroring `get_og_X`, so the no-arg form can pair each subject's observed time with their linear predictor in original data order regardless of how the Cox solver permutes internally.
- Two extra `StatsBase.predict(C, type, t)` methods that forward to the typed predict functions for `:expected` and `:survival` only; passing time with `:lp`, `:risk`, or `:terms` errors loudly.

Tests:
- Promote the two `@test_broken` R-matching tests to passing `@test`.
- Drop the two tests that were targeting the broken behaviour.
- Add a new @testitem "Cox predict at arbitrary times" covering shapes, monotonicity, S(0) ≈ 1, plateau past max(T), and error on misuse.

Docs:
- Document the three predict forms and the per-shape semantics.
- Add example invocations with scalar t and vector ts.