### PR TITLE
[Cox] Predict on new data

### DIFF
--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -272,6 +272,22 @@ predict(model, :survival, ts)
 
 Passing a time argument with `:lp`, `:risk`, or `:terms` is an error — those types do not depend on time.
 
+### Predict on new data
+
+Each `type` accepts a `newdata::DataFrame` argument. The fitted formula's schema is re-applied to `newdata` to build the new design matrix, so `newdata` must contain every predictor column referenced in the original `@formula(...)`. Centering is against the **training** reference subject (continuous covariates at their training mean, categorical at their training mode) — so predictions made on `newdata` are on the same absolute scale as the no-newdata path.
+
+```julia
+predict(model, :lp,    newdata)             # length-n_new vector
+predict(model, :risk,  newdata)             # length-n_new vector
+predict(model, :terms, newdata)             # n_new × p matrix
+predict(model, :expected, newdata, t)       # length-n_new at scalar t
+predict(model, :survival, newdata, t)
+predict(model, :expected, newdata, ts)      # n_new × length(ts) matrix
+predict(model, :survival, newdata, ts)
+```
+
+`:expected` and `:survival` on `newdata` **require** an explicit time argument — there is no "own time" default for arbitrary new subjects. Passing a time with `:lp` / `:risk` / `:terms` errors.
+
 ```@docs
 SurvivalModels.predict_expected
 ```

--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -40,8 +40,9 @@ struct Cox{CM}
     β::Vector{Float64}
     pred_names::Vector{Symbol}
     pred_types::Vector{Symbol}
-    function Cox(obj::CM, names, types) where {CM <: CoxMethod}
-        new{CM}(obj, getβ(obj), names, types)
+    formula::Union{FormulaTerm, Nothing}
+    function Cox(obj::CM, names, types; formula::Union{FormulaTerm, Nothing}=nothing) where {CM <: CoxMethod}
+        new{CM}(obj, getβ(obj), names, types, formula)
     end
 end
 
@@ -249,6 +250,95 @@ predict_survival(C::Cox)                     = exp.(-predict_expected(C))
 predict_survival(C::Cox, t::Real)            = exp.(-predict_expected(C, t))
 predict_survival(C::Cox, ts::AbstractVector) = exp.(-predict_expected(C, ts))
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Predict on new data
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Apply the fit's stored schema to `newdata` and return the design matrix `X_new`.
+# Errors if the model was constructed without a stored formula (e.g. by a direct
+# call to `Cox(obj, names, types)` without the keyword).
+function _build_X_for_newdata(C::Cox, newdata::DataFrame)
+    isnothing(C.formula) && error("This Cox model was constructed without a stored formula; predict-on-newdata is not available. Re-fit via `fit(Cox, @formula(...), df)` so the formula is captured.")
+    return modelcols(C.formula.rhs, newdata)
+end
+
+# Reference subject (1 × p row) from the training data: continuous covariates at
+# their training mean, categorical at their training mode. Used to centre linear
+# predictors at predict-time so the convention matches the no-newdata path and R.
+function _training_reference(C::Cox)
+    X_train = get_og_X(C.M)
+    d = nvar(C.M)
+    mX = zeros(1, d)
+    cat = C.pred_types .== :categorical
+    for i in 1:d
+        mX[1, i] = cat[i] ? mode(sort(X_train[:, i])) : mean(X_train[:, i])
+    end
+    return mX
+end
+
+# Linear predictor on new data, centred against the training reference by default.
+function predict_lp(C::Cox, newdata::DataFrame; centered::Bool=true)
+    X_new = _build_X_for_newdata(C, newdata)
+    η_new = X_new * C.β
+    centered || return η_new
+    return η_new .- (_training_reference(C) * C.β)[1]
+end
+
+# Relative risk `exp(η_new)` on new data.
+predict_risk(C::Cox, newdata::DataFrame) = exp.(predict_lp(C, newdata))
+
+# Per-subject × per-variable centred contributions to the linear predictor on new data.
+function predict_terms(C::Cox, newdata::DataFrame)
+    X_new = _build_X_for_newdata(C, newdata)
+    β = C.β
+    d = nvar(C.M)
+    rez = X_new .* β'
+    mX = _training_reference(C)
+    @inbounds for i in 1:d
+        rez[:, i] .-= mX[1, i] * β[i]
+    end
+    return rez
+end
+
+# Internal: `n_new × length(times)` matrix of cumulative hazards on newdata.
+function _predict_expected_at_newdata(C::Cox, newdata::DataFrame, times::AbstractVector)
+    Λ0 = baseline_hazard(C, centered=true)
+    t_grid = sort(unique(C.M.T))
+    η_new = exp.(predict_lp(C, newdata))
+    n, m = length(η_new), length(times)
+    out = Matrix{Float64}(undef, n, m)
+    @inbounds for j in 1:m
+        Λ_j = _cumhaz_at(Λ0, t_grid, times[j])
+        for i in 1:n
+            out[i, j] = Λ_j * η_new[i]
+        end
+    end
+    return out
+end
+
+"""
+    predict_expected(C::Cox, newdata::DataFrame, t::Real)
+    predict_expected(C::Cox, newdata::DataFrame, ts::AbstractVector)
+
+Per-subject cumulative hazard `Λᵢ(t)` for subjects in `newdata` evaluated at user-supplied
+times. Length-`n_new` vector for scalar `t`; `n_new × length(ts)` matrix for a vector.
+Centred against the training reference subject so the absolute scale matches the
+no-newdata path. Newdata predictions require an explicit time argument — there is no
+"own time" default for arbitrary new subjects.
+"""
+predict_expected(C::Cox, newdata::DataFrame, t::Real)            = vec(_predict_expected_at_newdata(C, newdata, [t]))
+predict_expected(C::Cox, newdata::DataFrame, ts::AbstractVector) = _predict_expected_at_newdata(C, newdata, ts)
+
+"""
+    predict_survival(C::Cox, newdata::DataFrame, t::Real)
+    predict_survival(C::Cox, newdata::DataFrame, ts::AbstractVector)
+
+Per-subject survival probability `Sᵢ(t) = exp(-Λᵢ(t))` on `newdata` at user times.
+Shapes match [`predict_expected`](@ref).
+"""
+predict_survival(C::Cox, newdata::DataFrame, t::Real)            = exp.(-predict_expected(C, newdata, t))
+predict_survival(C::Cox, newdata::DataFrame, ts::AbstractVector) = exp.(-predict_expected(C, newdata, ts))
+
 function StatsBase.predict(C::Cox, type::Symbol=:lp)
     type==:lp && return predict_lp(C)
     type==:risk && return predict_risk(C)
@@ -270,6 +360,26 @@ function StatsBase.predict(C::Cox, type::Symbol, ts::AbstractVector)
     error("Time-indexed `predict` only supports `:expected` and `:survival`, got `:$type`.")
 end
 
+function StatsBase.predict(C::Cox, type::Symbol, newdata::DataFrame)
+    type == :lp    && return predict_lp(C, newdata)
+    type == :risk  && return predict_risk(C, newdata)
+    type == :terms && return predict_terms(C, newdata)
+    type in (:expected, :survival) && error("`:$type` on newdata requires a time argument: predict(C, :$type, newdata, t).")
+    error("Unsupported predict type `:$type`. Supported on newdata: `:lp`, `:risk`, `:terms`, `:expected`, `:survival`.")
+end
+
+function StatsBase.predict(C::Cox, type::Symbol, newdata::DataFrame, t::Real)
+    type == :expected && return predict_expected(C, newdata, t)
+    type == :survival && return predict_survival(C, newdata, t)
+    error("Time-indexed `predict` on newdata only supports `:expected` and `:survival`, got `:$type`.")
+end
+
+function StatsBase.predict(C::Cox, type::Symbol, newdata::DataFrame, ts::AbstractVector)
+    type == :expected && return predict_expected(C, newdata, ts)
+    type == :survival && return predict_survival(C, newdata, ts)
+    error("Time-indexed `predict` on newdata only supports `:expected` and `:survival`, got `:$type`.")
+end
+
 function StatsBase.fit(::Type{T}, formula::FormulaTerm, df::DataFrame) where T<:Union{CoxMethod,Cox}
     CoxWorkerType = (isconcretetype(T) || T != Cox) ? T : CoxDefault
     formula_applied = apply_schema(formula, schema(df))
@@ -279,7 +389,7 @@ function StatsBase.fit(::Type{T}, formula::FormulaTerm, df::DataFrame) where T<:
     predictor_names = coefnames(formula_applied.rhs)
     catego = typeof.(formula_applied.rhs.terms) .<: CategoricalTerm
     catego = [c ? :categorical : :continuous for c in catego]
-    return Cox(CoxWorkerType(Y, Δ, X), Symbol.(predictor_names), catego)
+    return Cox(CoxWorkerType(Y, Δ, X), Symbol.(predictor_names), catego; formula = formula_applied)
 end
 
 """

--- a/test/test.jl
+++ b/test/test.jl
@@ -194,6 +194,74 @@ end
     end
 end
 
+
+@testitem "Cox predict on newdata" begin
+    using DataFrames
+    using SurvivalModels: predict, CoxNM, CoxOptim, CoxHessian, CoxDefault, CoxApprox
+
+    time   = [1.0, 3.0, 5.0, 6.0, 2.0, 7.0, 9.0, 11.0]
+    status = [true, false, true, true, true, false, true, true]
+    sex    = Symbol.([1, 1, 1, 1, 0, 0, 0, 0])
+    age    = [57, 52, 48, 42, 39, 31, 26, 22]
+    df     = DataFrame(time = time, status = status, sex = sex, age = age)
+    f      = @formula(Surv(time, status) ~ age + sex)
+    n      = length(time)
+
+    for M in (CoxNM, CoxOptim, CoxHessian, CoxDefault, CoxApprox)
+        model = fit(M, f, df)
+
+        # Self-consistency: passing the training df via the newdata path equals the
+        # no-newdata path that uses the model's internal X.
+        @test predict(model, :lp,    df) ≈ predict(model, :lp)         rtol = 1e-10
+        @test predict(model, :risk,  df) ≈ predict(model, :risk)       rtol = 1e-10
+        @test predict(model, :terms, df) ≈ predict(model, :terms)      rtol = 1e-10
+        @test predict(model, :expected, df, 1.0) ≈ predict(model, :expected, 1.0) rtol = 1e-10
+        @test predict(model, :survival, df, [0.5, 1.0]) ≈ predict(model, :survival, [0.5, 1.0]) rtol = 1e-10
+
+        # Held-out slice shapes
+        held = df[1:3, :]
+        @test size(predict(model, :lp,    held)) == (3,)
+        @test size(predict(model, :risk,  held)) == (3,)
+        @test size(predict(model, :terms, held)) == (3, 2)
+        @test size(predict(model, :expected, held, 5.0))           == (3,)
+        @test size(predict(model, :survival, held, [1.0, 5.0]))    == (3, 2)
+
+        # Survival on newdata is in [0,1] and non-increasing in t (per subject)
+        S = predict(model, :survival, held, [0.5, 1.0, 5.0, 11.0])
+        @test all(0 .≤ S .≤ 1 .+ 1e-12)
+        @test all(diff(S, dims = 2) .≤ 1e-12)
+
+        # Newdata predict requires time for :expected and :survival
+        @test_throws ErrorException predict(model, :expected, held)
+        @test_throws ErrorException predict(model, :survival, held)
+
+        # Newdata predict rejects time for :lp / :risk / :terms
+        @test_throws ErrorException predict(model, :lp,    held, 1.0)
+        @test_throws ErrorException predict(model, :risk,  held, 1.0)
+        @test_throws ErrorException predict(model, :terms, held, 1.0)
+    end
+end
+
+
+@testitem "Cox newdata predict errors without stored formula" begin
+    using DataFrames
+    using SurvivalModels: predict, CoxDefault, Cox
+
+    time   = [1.0, 3.0, 5.0, 6.0, 2.0, 7.0, 9.0, 11.0]
+    status = [true, false, true, true, true, false, true, true]
+    sex    = Symbol.([1, 1, 1, 1, 0, 0, 0, 0])
+    age    = [57, 52, 48, 42, 39, 31, 26, 22]
+    df     = DataFrame(time = time, status = status, sex = sex, age = age)
+
+    # Construct a Cox without a formula via the public constructor (backwards-compatible path)
+    # — simulate a direct-constructor user who didn't pass `formula = ...`.
+    X = hcat(age, [s == Symbol(1) ? 1.0 : 0.0 for s in sex])
+    worker = CoxDefault(time, Bool.(status), X)
+    bare = Cox(worker, [:age, :sex], [:continuous, :categorical])
+
+    @test_throws ErrorException predict(bare, :lp, df)
+end
+
 @testitem "Verify the correctness of the KaplanMeier implementation" begin
     using SurvivalModels: KaplanMeier
 


### PR DESCRIPTION
Adds support for evaluating a fitted `Cox` model on arbitrary new data via `predict(model, type, newdata)`. Follow-up to #46.

## Summary

The `Cox` struct gains an optional `formula::Union{FormulaTerm, Nothing}` field; `fit(Cox, @formula(...), df)` captures the schema-applied formula so it can be re-applied to `newdata` at predict time via `modelcols(C.formula.rhs, newdata)`. Backwards-compatible — the `formula = nothing` default keeps the existing `Cox(obj, names, types)` direct-constructor signature working; predict-on-newdata then errors with an explanatory message.

Seven new method signatures:

```julia
predict(model, :lp,    newdata)             # length-n_new vector
predict(model, :risk,  newdata)             # length-n_new vector
predict(model, :terms, newdata)             # n_new × p matrix
predict(model, :expected, newdata, t)       # length-n_new at scalar t
predict(model, :survival, newdata, t)
predict(model, :expected, newdata, ts)      # n_new × length(ts) matrix
predict(model, :survival, newdata, ts)
```

`:expected` and `:survival` on newdata **require** an explicit time argument — there is no "own time" default for arbitrary new subjects. Passing time with `:lp` / `:risk` / `:terms` errors loudly. Centring uses the **training** reference subject (continuous covariates at training mean, categorical at training mode) so newdata predictions are on the same absolute scale as the no-newdata path.

Two private helpers (`_build_X_for_newdata`, `_training_reference`) factor the shared work.

## Tests

Two new testitems in `test/test.jl`:

- **Cox predict on newdata** — self-consistency (newdata path on training df equals no-newdata path), held-out slice shapes, monotonicity of `:survival` in `t`, error paths for misuse, across all five `Cox` solver variants.
- **Cox newdata predict errors without stored formula** — verifies the `formula = nothing` direct-constructor path errors gracefully.

Test count: 231 → 317.

## Docs

New "Predict on new data" subsection in `docs/src/semiparametric/cox.md` listing the seven signatures and the centring convention.

## Out of scope

- `predict` for `GeneralHazardModel` (parametric AFT) on newdata — separate PR.
- Brier score / IPCW — depends on this PR; will follow.