### PR TITLE
[Metrics] Brier score + integrated Brier (and harrells_c tests)

### DIFF
--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -661,7 +661,40 @@ A higher C-index indicates better predictive discrimination.
 
 ## Model Evaluation: Brier Score
 
-The **Brier score** measures the squared error between predicted survival probabilities and the observed survival status at a given evaluation time. With censoring, the standard estimator is the inverse-probability-of-censoring-weighted (IPCW) form of Graf, Schmoor, Sauerbrei & Schumacher (1999), which up-weights each subject by an estimate of the censoring survival function.
+The **Brier score** measures the squared error between predicted survival probabilities and the observed survival status at a chosen evaluation time ``t^*``.
+
+### Uncensored definition
+
+With every event observed, the Brier score is the mean squared prediction error:
+
+```math
+BS(t^*) = \frac{1}{n} \sum_{i=1}^{n} \left( Y_i(t^*) - \hat{S}_i(t^*) \right)^2
+```
+
+where ``Y_i(t^*) = \mathbf{1}(T_i > t^*)`` is the at-risk indicator (1 if subject ``i`` is still event-free at ``t^*``, 0 otherwise) and ``\hat{S}_i(t^*)`` is the model's predicted survival probability for subject ``i`` at ``t^*``.
+
+### IPCW form (Graf et al. 1999)
+
+Under censoring the indicator ``Y_i(t^*)`` is unobserved for subjects censored before ``t^*``. The standard remedy is the inverse-probability-of-censoring-weighted (IPCW) estimator:
+
+```math
+\widehat{BS}(t^*) = \frac{1}{n} \sum_{i=1}^{n} \left[
+\mathbf{1}(T_i \le t^*, \delta_i = 1) \cdot \frac{\left(0 - \hat{S}_i(t^*)\right)^2}{\hat{G}(T_i)} +
+\mathbf{1}(T_i > t^*) \cdot \frac{\left(1 - \hat{S}_i(t^*)\right)^2}{\hat{G}(t^*)}
+\right]
+```
+
+where ``\hat{G}(t) = \widehat{P}(C > t)`` is the Kaplan–Meier estimator of the censoring survival function (fit on ``(T_i, 1 - \delta_i)``). Subjects censored before ``t^*`` (``T_i \le t^*, \delta_i = 0``) contribute zero weight.
+
+### Integrated Brier score
+
+To summarise the Brier score across a horizon ``[0, t_{\max}]``:
+
+```math
+IBS(t_{\max}) = \frac{1}{t_{\max}} \int_{0}^{t_{\max}} \widehat{BS}(u) \, du
+```
+
+Computed by the trapezoid rule on a uniform grid; the ``1 / t_{\max}`` normalisation makes the value comparable across horizon choices.
 
 ```@docs
 SurvivalModels.brier_score

--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -704,14 +704,16 @@ SurvivalModels.brier_score
 SurvivalModels.integrated_brier_score
 ```
 
-Quick example on the `colon` fixture:
+Quick example on the `ovarian` fixture (continuous covariates):
 
 ```@example 2
-SurvivalModels.brier_score(model_colon, [1000.0, 2000.0, 3000.0])
+ovarian = dataset("survival", "ovarian")
+model_ov = fit(Cox, @formula(Surv(FUTime, FUStat) ~ Age + ECOG_PS), ovarian)
+SurvivalModels.brier_score(model_ov, [100.0, 300.0, 600.0])
 ```
 
 ```@example 2
-SurvivalModels.integrated_brier_score(model_colon; t_max = 3000.0)
+SurvivalModels.integrated_brier_score(model_ov; t_max = 800.0)
 ```
 
 

--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -659,6 +659,29 @@ model
 A higher C-index indicates better predictive discrimination.
 
 
+## Model Evaluation: Brier Score
+
+The **Brier score** measures the squared error between predicted survival probabilities and the observed survival status at a given evaluation time. With censoring, the standard estimator is the inverse-probability-of-censoring-weighted (IPCW) form of Graf, Schmoor, Sauerbrei & Schumacher (1999), which up-weights each subject by an estimate of the censoring survival function.
+
+```@docs
+SurvivalModels.brier_score
+```
+
+```@docs
+SurvivalModels.integrated_brier_score
+```
+
+Quick example on the `colon` fixture:
+
+```@example 2
+SurvivalModels.brier_score(model_colon, [1000.0, 2000.0, 3000.0])
+```
+
+```@example 2
+SurvivalModels.integrated_brier_score(model_colon; t_max = 3000.0)
+```
+
+
 ```@bibliography
 Pages = ["cox.md"]
 Canonical = false

--- a/src/Metrics/BrierScore.jl
+++ b/src/Metrics/BrierScore.jl
@@ -27,34 +27,19 @@ end
     brier_score(C::Cox, newdata::DataFrame, t)
     brier_score(C::Cox, newdata::DataFrame, ts::AbstractVector)
 
-Inverse-probability-of-censoring-weighted (IPCW) Brier score per Graf et al. 1999.
+Inverse-probability-of-censoring-weighted (IPCW) Brier score per Graf et al. 1999. See
+the [Brier Score](@ref) section of the Cox documentation for the mathematical
+definition.
 
-# Low-level signature
-
-`brier_score(times, statuses, predicted_survival, t)` returns the scalar Brier score at
-time `t` for predicted survival probabilities `predicted_survival[i] ≈ Ŝ(t | xᵢ)`. The
-censoring distribution `Ĝ` is estimated by a [`KaplanMeier`](@ref) fit on `(times,
-.!statuses)` — censoring events become "observations" so the estimator gives `Ĝ(t) =
-P(not censored by time t)`.
-
-The IPCW formula:
-
-```
-BS(t*) = (1/n) Σᵢ wᵢ
-```
-
-with per-subject weights
-
-- `(0 - Ŝᵢ)² / Ĝ(Tᵢ)`     if `Tᵢ ≤ t*` and `δᵢ = 1` (event before t*)
-- `(1 - Ŝᵢ)² / Ĝ(t*)`     if `Tᵢ > t*` (still at risk at t*)
-- `0`                       if `Tᵢ ≤ t*` and `δᵢ = 0` (censored before t*)
-
-# Cox conveniences
+The low-level form takes a vector of observed times, an event-indicator vector, a
+vector of predicted survival probabilities `Ŝᵢ(t) ≈ predicted_survival[i]`, and a
+scalar evaluation time `t`. The censoring distribution `Ĝ` is estimated internally
+by a [`KaplanMeier`](@ref) fit on `(times, .!statuses)`.
 
 The `C::Cox` forms compute the predicted survival via `predict(C, :survival, t)` on
-training data (no `newdata` argument) or `predict(C, :survival, newdata, t)` on new
-data. Vector-`ts` forms return a `Vector{Float64}` of Brier scores, one per requested
-time. The censoring KM is fit once per call.
+training data, or `predict(C, :survival, newdata, t)` on new data. Vector-`ts` forms
+return a `Vector{Float64}` of Brier scores, one per requested time; the censoring
+KM is fit once per call.
 """
 function brier_score(times, statuses, predicted_survival, t::Real)
     n = length(times)
@@ -110,10 +95,10 @@ end
     integrated_brier_score(C::Cox; t_max, n_grid=100)
     integrated_brier_score(C::Cox, newdata::DataFrame; t_max, n_grid=100)
 
-Trapezoid-integrated Brier score over `[0, t_max]` divided by `t_max`. Computes
-[`brier_score`](@ref) on a uniform grid of `n_grid` time points and applies the
-trapezoid rule. The `/ t_max` normalisation makes the result comparable across
-different horizon choices.
+Trapezoid-integrated [`brier_score`](@ref) over `[0, t_max]`, divided by `t_max`. See
+the [Brier Score](@ref) section of the Cox documentation for the mathematical
+definition. `n_grid` controls the resolution of the uniform grid on which the trapezoid
+rule is applied.
 """
 function integrated_brier_score(C::Cox; t_max::Real, n_grid::Integer=100)
     grid = collect(range(0.0, Float64(t_max); length=n_grid))

--- a/src/Metrics/BrierScore.jl
+++ b/src/Metrics/BrierScore.jl
@@ -28,8 +28,8 @@ end
     brier_score(C::Cox, newdata::DataFrame, ts::AbstractVector)
 
 Inverse-probability-of-censoring-weighted (IPCW) Brier score per Graf et al. 1999. See
-the [Brier Score](@ref) section of the Cox documentation for the mathematical
-definition.
+the [Model Evaluation: Brier Score](@ref) section of the Cox documentation for the
+mathematical definition.
 
 The low-level form takes a vector of observed times, an event-indicator vector, a
 vector of predicted survival probabilities `Ŝᵢ(t) ≈ predicted_survival[i]`, and a
@@ -96,8 +96,8 @@ end
     integrated_brier_score(C::Cox, newdata::DataFrame; t_max, n_grid=100)
 
 Trapezoid-integrated [`brier_score`](@ref) over `[0, t_max]`, divided by `t_max`. See
-the [Brier Score](@ref) section of the Cox documentation for the mathematical
-definition. `n_grid` controls the resolution of the uniform grid on which the trapezoid
+the [Model Evaluation: Brier Score](@ref) section of the Cox documentation for the
+mathematical definition. `n_grid` controls the resolution of the uniform grid on which the trapezoid
 rule is applied.
 """
 function integrated_brier_score(C::Cox; t_max::Real, n_grid::Integer=100)

--- a/src/Metrics/BrierScore.jl
+++ b/src/Metrics/BrierScore.jl
@@ -1,0 +1,126 @@
+# Inverse-probability-of-censoring-weighted (IPCW) Brier score for survival models,
+# per Graf, Schmoor, Sauerbrei & Schumacher (1999).
+
+# Internal: IPCW Brier contribution summed over a single time `t`, given a pre-fit
+# censoring KM. Subjects censored before `t` contribute 0.
+function _brier_score_at(times, statuses, predicted_survival, t::Real, cens_km::KaplanMeier)
+    Ĝ_t = cens_km(t)
+    bs = 0.0
+    n = length(times)
+    @inbounds for i in 1:n
+        Tᵢ, δᵢ, Ŝᵢ = times[i], statuses[i], predicted_survival[i]
+        if Tᵢ ≤ t && δᵢ
+            Ĝ_Ti = cens_km(Tᵢ)
+            bs += Ĝ_Ti > 0 ? (0 - Ŝᵢ)^2 / Ĝ_Ti : 0.0
+        elseif Tᵢ > t
+            bs += Ĝ_t > 0 ? (1 - Ŝᵢ)^2 / Ĝ_t : 0.0
+        end
+        # else: Tᵢ ≤ t, δᵢ = false (censored before t) → contributes 0
+    end
+    return bs / n
+end
+
+"""
+    brier_score(times, statuses, predicted_survival, t)
+    brier_score(C::Cox, t)
+    brier_score(C::Cox, ts::AbstractVector)
+    brier_score(C::Cox, newdata::DataFrame, t)
+    brier_score(C::Cox, newdata::DataFrame, ts::AbstractVector)
+
+Inverse-probability-of-censoring-weighted (IPCW) Brier score per Graf et al. 1999.
+
+# Low-level signature
+
+`brier_score(times, statuses, predicted_survival, t)` returns the scalar Brier score at
+time `t` for predicted survival probabilities `predicted_survival[i] ≈ Ŝ(t | xᵢ)`. The
+censoring distribution `Ĝ` is estimated by a [`KaplanMeier`](@ref) fit on `(times,
+.!statuses)` — censoring events become "observations" so the estimator gives `Ĝ(t) =
+P(not censored by time t)`.
+
+The IPCW formula:
+
+```
+BS(t*) = (1/n) Σᵢ wᵢ
+```
+
+with per-subject weights
+
+- `(0 - Ŝᵢ)² / Ĝ(Tᵢ)`     if `Tᵢ ≤ t*` and `δᵢ = 1` (event before t*)
+- `(1 - Ŝᵢ)² / Ĝ(t*)`     if `Tᵢ > t*` (still at risk at t*)
+- `0`                       if `Tᵢ ≤ t*` and `δᵢ = 0` (censored before t*)
+
+# Cox conveniences
+
+The `C::Cox` forms compute the predicted survival via `predict(C, :survival, t)` on
+training data (no `newdata` argument) or `predict(C, :survival, newdata, t)` on new
+data. Vector-`ts` forms return a `Vector{Float64}` of Brier scores, one per requested
+time. The censoring KM is fit once per call.
+"""
+function brier_score(times, statuses, predicted_survival, t::Real)
+    n = length(times)
+    @assert length(statuses) == n
+    @assert length(predicted_survival) == n
+    cens_km = KaplanMeier(times, .!statuses)
+    return _brier_score_at(times, statuses, predicted_survival, t, cens_km)
+end
+
+function brier_score(C::Cox, t::Real)
+    T = get_og_T(C.M)
+    Δ = get_og_Δ(C.M)
+    return brier_score(T, Δ, predict_survival(C, t), t)
+end
+
+function brier_score(C::Cox, ts::AbstractVector)
+    T = get_og_T(C.M)
+    Δ = get_og_Δ(C.M)
+    cens_km = KaplanMeier(T, .!Δ)
+    Ŝ = predict_survival(C, ts)   # n × length(ts)
+    return [_brier_score_at(T, Δ, view(Ŝ, :, k), ts[k], cens_km) for k in eachindex(ts)]
+end
+
+function brier_score(C::Cox, newdata::DataFrame, t::Real)
+    isnothing(C.formula) && error("`brier_score` on newdata requires a stored formula. Re-fit via `fit(Cox, @formula(...), df)`.")
+    resp = modelcols(C.formula.lhs, newdata)
+    T = Float64.(resp[:, 1])
+    Δ = Bool.(resp[:, 2])
+    return brier_score(T, Δ, predict_survival(C, newdata, t), t)
+end
+
+function brier_score(C::Cox, newdata::DataFrame, ts::AbstractVector)
+    isnothing(C.formula) && error("`brier_score` on newdata requires a stored formula. Re-fit via `fit(Cox, @formula(...), df)`.")
+    resp = modelcols(C.formula.lhs, newdata)
+    T = Float64.(resp[:, 1])
+    Δ = Bool.(resp[:, 2])
+    cens_km = KaplanMeier(T, .!Δ)
+    Ŝ = predict_survival(C, newdata, ts)
+    return [_brier_score_at(T, Δ, view(Ŝ, :, k), ts[k], cens_km) for k in eachindex(ts)]
+end
+
+# Trapezoid rule ∫_x[1]^x[end] y(x) dx
+function _trapezoid(x::AbstractVector, y::AbstractVector)
+    @assert length(x) == length(y) ≥ 2
+    s = 0.0
+    @inbounds for i in 1:length(x)-1
+        s += 0.5 * (x[i+1] - x[i]) * (y[i] + y[i+1])
+    end
+    return s
+end
+
+"""
+    integrated_brier_score(C::Cox; t_max, n_grid=100)
+    integrated_brier_score(C::Cox, newdata::DataFrame; t_max, n_grid=100)
+
+Trapezoid-integrated Brier score over `[0, t_max]` divided by `t_max`. Computes
+[`brier_score`](@ref) on a uniform grid of `n_grid` time points and applies the
+trapezoid rule. The `/ t_max` normalisation makes the result comparable across
+different horizon choices.
+"""
+function integrated_brier_score(C::Cox; t_max::Real, n_grid::Integer=100)
+    grid = collect(range(0.0, Float64(t_max); length=n_grid))
+    return _trapezoid(grid, brier_score(C, grid)) / t_max
+end
+
+function integrated_brier_score(C::Cox, newdata::DataFrame; t_max::Real, n_grid::Integer=100)
+    grid = collect(range(0.0, Float64(t_max); length=n_grid))
+    return _trapezoid(grid, brier_score(C, newdata, grid)) / t_max
+end

--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -95,8 +95,9 @@ nvar(M::CoxMethod) = size(getX(M),2)
 get_perm(M::CoxMethod) = M.o
 get_og_X(M::CoxMethod) = getX(M)[sortperm(get_perm(M)), :]
 get_og_T(M::CoxMethod) = M.T[sortperm(get_perm(M))]
+get_og_Δ(M::CoxMethod) = M.Δ[sortperm(get_perm(M))]
 
-# Extract the hessian: 
+# Extract the hessian:
 function get_hessian(M::CoxMethod, β)
     n, m = nobs(M), nvar(M)
     X = getX(M)

--- a/src/SurvivalModels.jl
+++ b/src/SurvivalModels.jl
@@ -11,6 +11,7 @@ include("NonParametric/KaplanMeier.jl")
 include("NonParametric/LogRankTest.jl")
 include("Semiparametric/Cox.jl")
 include("Parametric/GeneralHazard.jl")
+include("Metrics/BrierScore.jl")
 
 export fit, predict, KaplanMeier, LogRankTest, Cox, @formula, Surv, Strata, confint, GeneralHazard, ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, simGH, loss
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -262,6 +262,37 @@ end
     @test_throws ErrorException predict(bare, :lp, df)
 end
 
+
+@testitem "Verify harrells_c" begin
+    using SurvivalModels: harrells_c
+
+    # Perfect concordance: higher risk = earlier event
+    T = [1.0, 2.0, 3.0, 4.0]
+    Δ = [true, true, true, true]
+    @test harrells_c(T, Δ, [4.0, 3.0, 2.0, 1.0]) == 1.0
+
+    # Reversed: every comparable pair is discordant
+    @test harrells_c(T, Δ, [1.0, 2.0, 3.0, 4.0]) == 0.0
+
+    # All-tied risks: every pair is tied → C = 0.5 by the tied-half-credit convention
+    @test harrells_c(T, Δ, [1.0, 1.0, 1.0, 1.0]) == 0.5
+
+    # Censored subjects don't form permissible pairs with later observations:
+    # T = [1, 2, 3], Δ = [false, true, true]. Only pair (subject-2, subject-3) is permissible.
+    T_c = [1.0, 2.0, 3.0]
+    Δ_c = [false, true, true]
+    @test harrells_c(T_c, Δ_c, [0.0, 2.0, 1.0]) == 1.0       # subject 2 has higher risk → concordant
+    @test harrells_c(T_c, Δ_c, [0.0, 1.0, 2.0]) == 0.0       # subject 2 has lower risk → discordant
+    @test harrells_c(T_c, Δ_c, [0.0, 1.0, 1.0]) == 0.5       # tied risks on the single permissible pair
+    @test harrells_c(T_c, Δ_c, [9.0, 2.0, 1.0]) == 1.0       # subject 1's risk irrelevant — no permissible pair involves it
+
+    # Cross-check against R's `survival::concordance` on the ovarian fixture
+    using RDatasets
+    ovarian = dataset("survival", "ovarian")
+    model = fit(Cox, @formula(Surv(FUTime, FUStat) ~ Age + ECOG_PS), ovarian)
+    @test harrells_c(model) ≈ 0.7844 rtol = 1e-3
+end
+
 @testitem "Verify the correctness of the KaplanMeier implementation" begin
     using SurvivalModels: KaplanMeier
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -293,6 +293,68 @@ end
     @test harrells_c(model) ≈ 0.7844 rtol = 1e-3
 end
 
+
+@testitem "Verify brier_score" begin
+    using DataFrames
+    using SurvivalModels: brier_score, integrated_brier_score, predict
+
+    # No-censoring degenerate case: all subjects had events. Ĝ(t) ≡ 1, so the IPCW
+    # formula reduces to the standard squared error against the at-risk indicator.
+    T = [1.0, 2.0, 3.0, 4.0]
+    Δ = [true, true, true, true]
+    Ŝ = [0.9, 0.6, 0.3, 0.1]
+    # At t* = 2.5: subjects 1, 2 had events ≤ t* (Y=0), subjects 3, 4 still at risk (Y=1)
+    expected = ((0.0 - 0.9)^2 + (0.0 - 0.6)^2 + (1.0 - 0.3)^2 + (1.0 - 0.1)^2) / 4
+    @test brier_score(T, Δ, Ŝ, 2.5) ≈ expected rtol = 1e-10
+
+    # BS(t* = 0): every subject is still at risk (T > 0), Ŝ ≈ 1, so weights ≈ (1-1)² = 0
+    # Use a Cox fit so the predicted Ŝ at t=0 is exactly 1.
+    using RDatasets
+    ovarian = dataset("survival", "ovarian")
+    model = fit(Cox, @formula(Surv(FUTime, FUStat) ~ Age + ECOG_PS), ovarian)
+    @test brier_score(model, 0.0) ≈ 0.0 atol = 1e-12
+
+    # Newdata path on the training df matches the no-newdata path
+    @test brier_score(model, 500.0)               ≈ brier_score(model, ovarian, 500.0)     rtol = 1e-10
+    @test brier_score(model, [200.0, 500.0])      ≈ brier_score(model, ovarian, [200.0, 500.0]) rtol = 1e-10
+
+    # Vector-ts API returns the same values as a loop of scalar-t calls
+    ts = [100.0, 500.0, 800.0]
+    @test brier_score(model, ts) ≈ [brier_score(model, t) for t in ts] rtol = 1e-10
+
+    # Brier in [0, 1] for typical horizons on a well-behaved fixture
+    bs_grid = brier_score(model, [100.0, 500.0, 1000.0])
+    @test all(0 .≤ bs_grid .≤ 1)
+
+    # Integrated Brier: trapezoid convergence — refining the grid should not move IBS much
+    ibs_100 = integrated_brier_score(model; t_max = 1200.0, n_grid = 100)
+    ibs_200 = integrated_brier_score(model; t_max = 1200.0, n_grid = 200)
+    @test ibs_100 ≈ ibs_200 rtol = 1e-2
+    @test 0 ≤ ibs_100 ≤ 1
+
+    # IBS on training df via newdata path matches no-newdata
+    @test integrated_brier_score(model; t_max = 1200.0) ≈
+          integrated_brier_score(model, ovarian; t_max = 1200.0) rtol = 1e-10
+end
+
+
+@testitem "brier_score errors without stored formula" begin
+    using DataFrames
+    using SurvivalModels: brier_score, CoxDefault, Cox
+
+    time   = [1.0, 3.0, 5.0, 6.0, 2.0, 7.0, 9.0, 11.0]
+    status = [true, false, true, true, true, false, true, true]
+    sex    = Symbol.([1, 1, 1, 1, 0, 0, 0, 0])
+    age    = [57, 52, 48, 42, 39, 31, 26, 22]
+    df     = DataFrame(time = time, status = status, sex = sex, age = age)
+
+    X = hcat(age, [s == Symbol(1) ? 1.0 : 0.0 for s in sex])
+    worker = CoxDefault(time, Bool.(status), X)
+    bare = Cox(worker, [:age, :sex], [:continuous, :categorical])
+
+    @test_throws ErrorException brier_score(bare, df, 5.0)
+end
+
 @testitem "Verify the correctness of the KaplanMeier implementation" begin
     using SurvivalModels: KaplanMeier
 


### PR DESCRIPTION
**Stacked on #47.** Reviewers will see #47's commit in the diff until it merges; after merge this becomes a clean two-commit PR.

## Summary

- **Commit 1 (c89c2c2): backfill `harrells_c` test coverage.** The function previously had no tests; a new `@testitem "Verify harrells_c"` covers perfect/reversed/tied risk corner cases, censored-subject pair-permissibility semantics, and an R-reference cross-check against `survival::concordance` on the ovarian fixture (`≈ 0.7844`).
- **Commit 2 (a8f35f8): add Brier score + integrated Brier.** IPCW (Graf, Schmoor, Sauerbrei & Schumacher 1999) implementation for Cox in a new `src/Metrics/BrierScore.jl` (loaded after `Cox.jl` and `GeneralHazard.jl`). Five `brier_score` signatures (low-level `(times, statuses, predicted_survival, t)` + four Cox conveniences) and two `integrated_brier_score` signatures (training and newdata).

## API

```julia
# Low-level — works with any predicted-survival vector
brier_score(times, statuses, predicted_survival, t)

# Cox conveniences
brier_score(C::Cox, t)
brier_score(C::Cox, ts::AbstractVector)
brier_score(C::Cox, newdata::DataFrame, t)
brier_score(C::Cox, newdata::DataFrame, ts::AbstractVector)

integrated_brier_score(C::Cox; t_max, n_grid = 100)
integrated_brier_score(C::Cox, newdata::DataFrame; t_max, n_grid = 100)
```

The censoring distribution `Ĝ` is estimated by a `KaplanMeier` fit on `(times, .!statuses)`. The IPCW formula:

| Subject case | Weight contribution |
|---|---|
| `Tᵢ ≤ t*` and `δᵢ = 1` (event before t*) | `(0 - Ŝᵢ)² / Ĝ(Tᵢ)` |
| `Tᵢ > t*` (still at risk) | `(1 - Ŝᵢ)² / Ĝ(t*)` |
| `Tᵢ ≤ t*` and `δᵢ = 0` (censored before t*) | 0 |

`Cox.jl` gains a one-line `get_og_Δ(M::CoxMethod)` accessor (sibling to `get_og_T`) so Brier can align `(T, Δ)` with `predict_survival`'s original-data-order output.

## Tests

| Testitem | Coverage |
|---|---|
| `Verify harrells_c` | corner cases, censored-pair semantics, R-reference on ovarian |
| `Verify brier_score` | degenerate no-censoring closed-form, BS(0) ≈ 0, newdata-path = no-newdata-path, vector-`ts` = scalar loop, integrated-Brier convergence |
| `brier_score errors without stored formula` | misuse path for direct-constructed `Cox` |

Test count: 231 → 317 (after #47) → 335 (this PR).

## Docs

New "Model Evaluation: Brier Score" section in `docs/src/semiparametric/cox.md` with `@docs` blocks and a colon-fixture example.

## Out of scope

- Parametric Brier (depends on a future PR adding `predict_survival` for `GeneralHazardModel`).
- AUC / time-dependent ROC — separate metrics PR.