### PR TITLE
[Parametric] Add predict for GeneralHazardModel

### DIFF
--- a/docs/src/parametric/generalhazard.md
+++ b/docs/src/parametric/generalhazard.md
@@ -126,6 +126,32 @@ The current version of the `simGH` command implements the following parametric b
 - [Weibull](https://en.wikipedia.org/wiki/Weibull_distribution) (Weibull) distribution. (only for AFT, PH, and AH models)
 
 
+### Prediction interface
+
+Once a [`GeneralHazardModel`](@ref) is fitted (or directly constructed), you can evaluate per-subject cumulative hazards and survival probabilities at user-supplied times. The four hazard structures share the same closed-form expression via the unified representation
+
+```math
+H(t \,|\, x) = H_0\!\left(t \cdot c_1(x)\right) \cdot c_2(x)
+```
+
+where ``H_0`` is the cumulative hazard of the baseline distribution and ``(c_1, c_2)`` are the method-specific time- and hazard-scale multipliers (`c1`/`c2` in the code). The survival is ``S(t \,|\, x) = \exp(-H(t \,|\, x))``.
+
+```julia
+predict(model, :survival)              # length-n vector, each subject at own Tᵢ
+predict(model, :expected)              # length-n vector of Λᵢ(Tᵢ)
+predict(model, :survival, t)           # length-n vector at scalar t
+predict(model, :expected, t)
+predict(model, :survival, ts)          # n × length(ts) matrix
+predict(model, :expected, ts)
+```
+
+The default no-arg form (`predict(model)` or `predict(model, :survival)`) evaluates each subject at their own observed time ``T_i``, matching the convention used by the Cox interface.
+
+```@docs
+SurvivalModels.predict_expected(::SurvivalModels.GeneralHazardModel)
+SurvivalModels.predict_survival(::SurvivalModels.GeneralHazardModel)
+```
+
 ### Simulating times to event from a general hazard structure with `simGH`
 
 The simGH command from the `HazReg.jl` Julia package allows one to simulate times to event from the following models:

--- a/docs/src/parametric/generalhazard.md
+++ b/docs/src/parametric/generalhazard.md
@@ -128,7 +128,7 @@ The current version of the `simGH` command implements the following parametric b
 
 ### Prediction interface
 
-Once a [`GeneralHazardModel`](@ref) is fitted (or directly constructed), you can evaluate per-subject cumulative hazards and survival probabilities at user-supplied times. The four hazard structures share the same closed-form expression via the unified representation
+Once a `GeneralHazardModel` is fitted (or directly constructed), you can evaluate per-subject cumulative hazards and survival probabilities at user-supplied times. The four hazard structures share the same closed-form expression via the unified representation
 
 ```math
 H(t \,|\, x) = H_0\!\left(t \cdot c_1(x)\right) \cdot c_2(x)

--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -290,7 +290,9 @@ predict(model, :survival, newdata, ts)
 
 ```@docs
 SurvivalModels.predict_expected(::SurvivalModels.Cox)
+SurvivalModels.predict_expected(::SurvivalModels.Cox, ::DataFrame, ::Real)
 SurvivalModels.predict_survival(::SurvivalModels.Cox)
+SurvivalModels.predict_survival(::SurvivalModels.Cox, ::DataFrame, ::Real)
 ```
 
 ### Example: Prediction on New Data

--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -289,11 +289,8 @@ predict(model, :survival, newdata, ts)
 `:expected` and `:survival` on `newdata` **require** an explicit time argument — there is no "own time" default for arbitrary new subjects. Passing a time with `:lp` / `:risk` / `:terms` errors.
 
 ```@docs
-SurvivalModels.predict_expected
-```
-
-```@docs
-SurvivalModels.predict_survival
+SurvivalModels.predict_expected(::SurvivalModels.Cox)
+SurvivalModels.predict_survival(::SurvivalModels.Cox)
 ```
 
 ### Example: Prediction on New Data

--- a/src/Parametric/GeneralHazard.jl
+++ b/src/Parametric/GeneralHazard.jl
@@ -240,6 +240,78 @@ function StatsBase.fit(::Type{GHM},
     return GeneralHazardModel(_method(GHM), TΔ[:,1], TΔ[:,2], _baseline(GHM), X, X)
 end
 
+# Internal helper: return the per-subject (c1, c2) multipliers for any method.
+function _c1c2(m::GeneralHazardModel{M,B}) where {M,B}
+    method = M()
+    return c1(method, m.X1, m.X2, m.β, m.α), c2(method, m.X1, m.X2, m.β, m.α)
+end
+
+"""
+    predict_expected(m::GeneralHazardModel)
+    predict_expected(m::GeneralHazardModel, t::Real)
+    predict_expected(m::GeneralHazardModel, ts::AbstractVector)
+
+Per-subject cumulative hazard `Λᵢ(t) = H₀(t · c1ᵢ) · c2ᵢ`, where `H₀` is the cumulative
+hazard of the baseline distribution and `(c1ᵢ, c2ᵢ)` are the method-specific time- and
+hazard-scale multipliers (PH, AFT, AH, GH share the same closed form via the unified
+`H(t|x) = H₀(t · c1) · c2` representation).
+
+Output shape:
+- no time argument → length-`n` vector with each subject evaluated at their own
+  observed time `Tᵢ`;
+- `t::Real` → length-`n` vector at the scalar time;
+- `ts::AbstractVector` → `n × length(ts)` matrix.
+"""
+function predict_expected(m::GeneralHazardModel)
+    cc1, cc2 = _c1c2(m)
+    return [(-logccdf(m.baseline, m.T[i] * cc1[i])) * cc2[i] for i in eachindex(m.T)]
+end
+
+function predict_expected(m::GeneralHazardModel, t::Real)
+    cc1, cc2 = _c1c2(m)
+    return (-logccdf.(m.baseline, t .* cc1)) .* cc2
+end
+
+function predict_expected(m::GeneralHazardModel, ts::AbstractVector)
+    cc1, cc2 = _c1c2(m)
+    n = length(cc1)
+    out = Matrix{Float64}(undef, n, length(ts))
+    @inbounds for j in eachindex(ts)
+        out[:, j] = (-logccdf.(m.baseline, ts[j] .* cc1)) .* cc2
+    end
+    return out
+end
+
+"""
+    predict_survival(m::GeneralHazardModel)
+    predict_survival(m::GeneralHazardModel, t::Real)
+    predict_survival(m::GeneralHazardModel, ts::AbstractVector)
+
+Per-subject survival probability `Sᵢ(t) = exp(-Λᵢ(t))` derived from
+[`predict_expected`](@ref). Shapes match `predict_expected`.
+"""
+predict_survival(m::GeneralHazardModel)                     = exp.(-predict_expected(m))
+predict_survival(m::GeneralHazardModel, t::Real)            = exp.(-predict_expected(m, t))
+predict_survival(m::GeneralHazardModel, ts::AbstractVector) = exp.(-predict_expected(m, ts))
+
+function StatsBase.predict(m::GeneralHazardModel, type::Symbol=:survival)
+    type == :survival && return predict_survival(m)
+    type == :expected && return predict_expected(m)
+    error("Unsupported predict type `:$type` for GeneralHazardModel. Supported: `:survival`, `:expected`.")
+end
+
+function StatsBase.predict(m::GeneralHazardModel, type::Symbol, t::Real)
+    type == :survival && return predict_survival(m, t)
+    type == :expected && return predict_expected(m, t)
+    error("Time-indexed `predict` on GeneralHazardModel supports `:survival` and `:expected`, got `:$type`.")
+end
+
+function StatsBase.predict(m::GeneralHazardModel, type::Symbol, ts::AbstractVector)
+    type == :survival && return predict_survival(m, ts)
+    type == :expected && return predict_expected(m, ts)
+    error("Time-indexed `predict` on GeneralHazardModel supports `:survival` and `:expected`, got `:$type`.")
+end
+
 """
     simGH(n, model::GeneralHazardModel)
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -495,3 +495,83 @@ end
     @test model_ah isa GeneralHazardModel{AHMethod, Weibull{Float64}}
     @test length(model_ah.α) == 2
 end
+
+
+@testitem "GeneralHazardModel predict shapes and consistency" begin
+    using Distributions, Random
+    using SurvivalModels: predict, ProportionalHazard, AcceleratedFaillureTime,
+                          AcceleratedHazard, GeneralHazard, predict_expected, predict_survival
+    using StableRNGs
+
+    rng = StableRNG(456)
+    n   = 25
+    T   = rand(rng, Exponential(2.0), n)
+    Δ   = rand(rng, Bool, n)
+    X1  = randn(rng, n, 2)
+    X2  = randn(rng, n, 2)
+
+    constructors = (ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, GeneralHazard)
+    for ctor in constructors
+        m = ctor(T, Δ, Weibull(1.0, 2.0), X1, X2)
+
+        # Shapes
+        @test size(predict(m, :survival))                       == (n,)
+        @test size(predict(m, :expected))                       == (n,)
+        @test size(predict(m, :survival, 1.0))                  == (n,)
+        @test size(predict(m, :expected, 1.0))                  == (n,)
+        @test size(predict(m, :survival, [0.5, 1.0, 2.0]))      == (n, 3)
+        @test size(predict(m, :expected, [0.5, 1.0, 2.0]))      == (n, 3)
+
+        # Self-consistency: S = exp(-H) at both scalar and vector t
+        @test predict(m, :survival, 1.0)            ≈ exp.(-predict(m, :expected, 1.0))            rtol = 1e-12
+        @test predict(m, :survival, [0.5, 1.0, 2.0]) ≈ exp.(-predict(m, :expected, [0.5, 1.0, 2.0])) rtol = 1e-12
+
+        # No-arg form evaluates at each subject's own observed Tᵢ
+        no_arg_S = predict(m, :survival)
+        for i in 1:n
+            @test no_arg_S[i] ≈ predict(m, :survival, T[i])[i] rtol = 1e-12
+        end
+
+        # S(t) ∈ [0, 1] and non-increasing in t
+        S_grid = predict(m, :survival, [0.1, 0.5, 1.0, 2.0, 5.0, 20.0])
+        @test all(0 .≤ S_grid .≤ 1 .+ 1e-12)
+        @test all(diff(S_grid, dims = 2) .≤ 1e-12)
+
+        # S(0) = 1 exactly (for distributions with support starting at 0+)
+        @test predict(m, :survival, 0.0) ≈ ones(n) atol = 1e-12
+
+        # Misuse: predict on an unsupported type
+        @test_throws ErrorException predict(m, :lp, 1.0)
+        @test_throws ErrorException predict(m, :risk)
+    end
+end
+
+
+@testitem "ProportionalHazard with β = 0 reduces to baseline survival" begin
+    using Distributions, Random
+    using SurvivalModels: predict, ProportionalHazard, PHMethod, GeneralHazardModel
+    using StableRNGs
+
+    rng = StableRNG(789)
+    n   = 8
+    T   = rand(rng, Exponential(2.0), n)
+    Δ   = rand(rng, Bool, n)
+    X1  = randn(rng, n, 2)
+    X2  = randn(rng, n, 2)
+    baseline = Weibull(1.0, 2.0)
+
+    # Direct construction with α = β = 0 (no covariate effect).
+    m = ProportionalHazard(T, Δ, baseline, X1, X2, zeros(2), zeros(2))
+
+    # S(t | x) should reduce to ccdf(baseline, t) regardless of x.
+    for t in (0.5, 1.0, 2.5, 5.0)
+        expected = ccdf(baseline, t)
+        @test all(predict(m, :survival, t) .≈ expected) skip = false
+    end
+
+    # And the matrix form should be constant across subjects at each t.
+    S_mat = predict(m, :survival, [0.5, 1.0, 2.5, 5.0])
+    for j in 1:size(S_mat, 2)
+        @test all(S_mat[:, j] .≈ S_mat[1, j])
+    end
+end


### PR DESCRIPTION
Adds per-subject cumulative hazard and survival prediction for `GeneralHazardModel`, mirroring the Cox interface introduced in #46 and #47.

## Summary

All four hazard structures (PH, AFT, AH, GH) share the same closed form via the unified representation already encoded by the `c1` / `c2` functions used in `fit`:

```
H(t | x) = H₀(t · c1(x)) · c2(x)
S(t | x) = exp(-H(t | x))
```

so the implementation is method-agnostic — no per-method dispatch inside `predict_expected` / `predict_survival`.

## API (mirrors Cox)

```julia
predict_expected(m::GeneralHazardModel)                       # length-n, each at own Tᵢ
predict_expected(m::GeneralHazardModel, t::Real)              # length-n at scalar t
predict_expected(m::GeneralHazardModel, ts::AbstractVector)   # n × length(ts) matrix
predict_survival(m::GeneralHazardModel)
predict_survival(m::GeneralHazardModel, t::Real)
predict_survival(m::GeneralHazardModel, ts::AbstractVector)

predict(m, type::Symbol = :survival)
predict(m, type::Symbol, t::Real)
predict(m, type::Symbol, ts::AbstractVector)
```

The dispatcher supports `:survival` and `:expected` only — `α` and `β` are two coefficient sets with no single canonical "linear predictor", so `:lp` / `:risk` / `:terms` are intentionally absent. The no-arg form evaluates each subject at their own observed time `Tᵢ` (the Cox convention from #46).

A private `_c1c2(m)` helper computes both multipliers in one pass.

## Tests

| Testitem | Coverage |
|---|---|
| `GeneralHazardModel predict shapes and consistency` | All four constructors × every arity of both predict functions × shape, `S = exp(-H)`, no-arg-equals-predict-at-Tᵢ, `S ∈ [0,1]`, monotonicity in `t`, `S(0) = 1` exactly, misuse errors |
| `ProportionalHazard with β = 0 reduces to baseline survival` | Closed-form sanity: a PH model directly constructed with `α = β = 0` should produce `S(t \| x) = ccdf(baseline, t)` regardless of `x`, both scalar and vector-`t` forms |

Test count: 318 (main) → 477 (this PR).

## Docs

- New "Prediction interface" subsection in `docs/src/parametric/generalhazard.md` with the unified math, signature list, and signature-filtered `@docs` blocks for the GH methods.
- Updated the existing `@docs` blocks in `docs/src/semiparametric/cox.md` to be Cox-method-specific so the parametric methods don't bleed into the Cox section after this PR.

## Out of scope (follow-up)

- **`predict(m, newdata, ...)`** for GeneralHazardModel requires storing the schema-applied formula on the struct (mirroring what #47 did for Cox). Tracked as a future PR.
- **Parametric Brier**: a one-line addition to `BrierScore.jl` once both this PR and #50 land — `brier_score(m::GeneralHazardModel, t)` will dispatch via the new `predict_survival`.