### PR TITLE
[Cox] Fix pred_types length for multi-level categoricals (closes #52)

### DIFF
--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -387,8 +387,14 @@ function StatsBase.fit(::Type{T}, formula::FormulaTerm, df::DataFrame) where T<:
     X = modelcols(formula_applied.rhs, df)
     Y, Δ = resp[:, 1], Bool.(resp[:, 2])
     predictor_names = coefnames(formula_applied.rhs)
-    catego = typeof.(formula_applied.rhs.terms) .<: CategoricalTerm
-    catego = [c ? :categorical : :continuous for c in catego]
+    # `pred_types` must be one entry per design-matrix column so the per-column
+    # loops in `predict_lp`, `predict_terms`, and `_training_reference` stay aligned.
+    # A k-level categorical with reference encoding contributes `width(term) = k - 1`
+    # columns, not 1, so we expand the per-term tag accordingly.
+    catego = mapreduce(vcat, formula_applied.rhs.terms; init = Symbol[]) do term
+        is_cat = term isa CategoricalTerm
+        fill(is_cat ? :categorical : :continuous, StatsModels.width(term))
+    end
     return Cox(CoxWorkerType(Y, Δ, X), Symbol.(predictor_names), catego; formula = formula_applied)
 end
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -262,6 +262,47 @@ end
     @test_throws ErrorException predict(bare, :lp, df)
 end
 
+
+@testitem "Cox handles multi-level categorical predictors" begin
+    # Regression test for the BoundsError reported in #52: `predict_lp` and
+    # `predict_terms` index `pred_types` column-wise, but fit previously built
+    # it term-wise — so any k-level categorical with k ≥ 3 broke every predict
+    # path that goes through the centring loop.
+    using DataFrames, Random
+    using SurvivalModels: predict, nvar
+
+    rng = MersenneTwister(123)
+    n   = 50
+    df  = DataFrame(
+        time   = rand(rng, n) .* 10 .+ 0.1,
+        status = rand(rng, Bool, n),
+        age    = randn(rng, n),
+        rx     = Symbol.(rand(rng, [:a, :b, :c], n)),   # 3-level categorical
+    )
+    model = fit(Cox, @formula(Surv(time, status) ~ age + rx), df)
+
+    # The invariant: pred_types is per-design-column, same length as pred_names
+    # and `nvar(C.M)`. With reference encoding on a 3-level factor we expect
+    # `[:continuous, :categorical, :categorical]`.
+    @test length(model.pred_types) == length(model.pred_names)
+    @test length(model.pred_types) == nvar(model.M)
+    @test model.pred_types == [:continuous, :categorical, :categorical]
+
+    # Every prediction mode runs without BoundsError and returns the expected
+    # shape. The actual numerical values are exercised by other testitems on
+    # simpler fixtures.
+    @test size(predict(model, :lp))                 == (n,)
+    @test size(predict(model, :risk))               == (n,)
+    @test size(predict(model, :terms))              == (n, nvar(model.M))
+    @test size(predict(model, :expected))           == (n,)
+    @test size(predict(model, :survival))           == (n,)
+    @test size(predict(model, :expected, 5.0))      == (n,)
+    @test size(predict(model, :survival, [1.0, 5.0])) == (n, 2)
+
+    # Newdata path also exercises predict_lp through _build_X_for_newdata.
+    @test size(predict(model, :lp, df)) == (n,)
+end
+
 @testitem "Verify the correctness of the KaplanMeier implementation" begin
     using SurvivalModels: KaplanMeier
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -301,6 +301,8 @@ end
 
     # Newdata path also exercises predict_lp through _build_X_for_newdata.
     @test size(predict(model, :lp, df)) == (n,)
+end
+
 @testitem "Verify harrells_c" begin
     using SurvivalModels: harrells_c
 


### PR DESCRIPTION
Closes #52.

## Summary

`fit(Cox, ...)` previously built `pred_types` **term-wise**:

```julia
catego = typeof.(formula_applied.rhs.terms) .<: CategoricalTerm
```

while `pred_names` is **column-wise** (`coefnames(rhs)`). With a `k`-level categorical and reference encoding the term contributes `k - 1` design-matrix columns, so the two diverged whenever `k ≥ 3`.

The per-column loops in `predict_lp`, `predict_terms`, and the `_training_reference` helper iterate `for i in 1:nvar(C.M)` and index `cat[i]` — overrunning the shorter `pred_types` and raising `BoundsError` on every `predict(model, :lp) / :risk / :terms / :expected / :survival` call (plus `brier_score` and any other downstream consumer).

## Fix

Build `pred_types` per design-matrix column at fit time using `StatsModels.width(term)`:

```julia
catego = mapreduce(vcat, formula_applied.rhs.terms; init = Symbol[]) do term
    is_cat = term isa CategoricalTerm
    fill(is_cat ? :categorical : :continuous, StatsModels.width(term))
end
```

`width(term)` returns the number of design-matrix columns the term contributes — 1 for a continuous term, `k - 1` for a `k`-level categorical with reference encoding. After the fix `length(pred_types) == length(pred_names) == nvar(C.M)` always holds, and the downstream per-column loops work unchanged.

## Regression test

New `@testitem "Cox handles multi-level categorical predictors"`:

- Fits Cox on a synthetic fixture with a 3-level `rx` predictor.
- Asserts the alignment invariant `length(pred_types) == length(pred_names) == nvar(model.M)`.
- Asserts the expected expansion: `pred_types == [:continuous, :categorical, :categorical]`.
- Exercises every prediction mode (`:lp`, `:risk`, `:terms`, `:expected`, `:survival`, plus the newdata `:lp` path) for absence of `BoundsError`.

Test count: 317 (main) → 328 (this PR).

## Scope

- Minimal targeted fix; no restructuring of the per-column loops downstream.
- No doc changes — the existing prose stays correct.