### PR TITLE
[Parametric] Predict on new data for GeneralHazardModel

### DIFF
--- a/docs/src/parametric/generalhazard.md
+++ b/docs/src/parametric/generalhazard.md
@@ -147,6 +147,19 @@ predict(model, :expected, ts)
 
 The default no-arg form (`predict(model)` or `predict(model, :survival)`) evaluates each subject at their own observed time ``T_i``, matching the convention used by the Cox interface.
 
+#### Predict on new data
+
+Each prediction also accepts a `newdata::DataFrame` argument. The fit's stored formula(s) are re-applied to `newdata` to rebuild the design matrices ``X_1``, ``X_2``, so `newdata` must contain every predictor column referenced in the original `@formula(...)`. For models fit with `fit(GHM, formula, df)` (one formula), the same formula is stored twice and used for both ``X_1`` and ``X_2``; for `fit(GeneralHazard, formula1, formula2, df)` the two are stored separately.
+
+```julia
+predict(model, :survival, newdata, t)        # length-n_new at scalar t
+predict(model, :expected, newdata, t)
+predict(model, :survival, newdata, ts)       # n_new × length(ts) matrix
+predict(model, :expected, newdata, ts)
+```
+
+Newdata predict **requires** an explicit time argument — there is no "own time" default for arbitrary new subjects. Models built directly via the positional constructor (without the `formula1` / `formula2` keyword arguments) do not have stored formulas and will error on newdata predict.
+
 ```@docs
 SurvivalModels.predict_expected(::SurvivalModels.GeneralHazardModel)
 SurvivalModels.predict_survival(::SurvivalModels.GeneralHazardModel)

--- a/src/Parametric/GeneralHazard.jl
+++ b/src/Parametric/GeneralHazard.jl
@@ -55,20 +55,27 @@ struct GeneralHazardModel{Method, B}
     X2::Matrix{Float64}
     α::Vector{Float64}
     β::Vector{Float64}
+    formula1::Union{FormulaTerm, Nothing}
+    formula2::Union{FormulaTerm, Nothing}
 
     # Direct constructor: all parameters provided, no optimization
-    function GeneralHazardModel(::Method, T, Δ, baseline::B, X1, X2, α, β) where {Method<:AbstractGHMethod, B}
-        X1 = length(size(X1)) == 2 ? X1 : reshape(X1, :, 1) # X1 and X2 must be matrices. 
+    function GeneralHazardModel(::Method, T, Δ, baseline::B, X1, X2, α, β;
+                                formula1::Union{FormulaTerm, Nothing}=nothing,
+                                formula2::Union{FormulaTerm, Nothing}=nothing) where {Method<:AbstractGHMethod, B}
+        X1 = length(size(X1)) == 2 ? X1 : reshape(X1, :, 1) # X1 and X2 must be matrices.
         X2 = length(size(X2)) == 2 ? X2 : reshape(X2, :, 1)
         return new{Method, B}(
             collect(T), Bool.(Δ), baseline,
             Matrix{Float64}(X1), Matrix{Float64}(X2),
-            collect(α), collect(β)
+            collect(α), collect(β),
+            formula1, formula2,
         )
     end
 
     # Existing constructor with optimizer (kept as is)
-    function GeneralHazardModel(m::Method, T, Δ, baseline, X1, X2) where {Method<:AbstractGHMethod}
+    function GeneralHazardModel(m::Method, T, Δ, baseline, X1, X2;
+                                formula1::Union{FormulaTerm, Nothing}=nothing,
+                                formula2::Union{FormulaTerm, Nothing}=nothing) where {Method<:AbstractGHMethod}
         npd, p, q = length(Distributions.params(baseline)), size(X1,2), size(X2,2)
         init = zeros(npd+p+q)
         base_T = typeof(baseline).name.wrapper
@@ -85,7 +92,7 @@ struct GeneralHazardModel{Method, B}
         end
         par = optimize(mloglik, init, method=LBFGS()).minimizer
         d, α, β = base_T(exp.(par[1:npd])...), par[npd .+ (1:q)], par[npd + q .+ (1:p)]
-        return new{Method, typeof(d)}(T, Δ, d, X1, X2, α, β)
+        return new{Method, typeof(d)}(T, Δ, d, X1, X2, α, β, formula1, formula2)
     end
 end
 
@@ -227,7 +234,8 @@ function StatsBase.fit(::Type{GHM},
     X1 = modelcols(f1_applied.rhs, df)
     X2 = modelcols(f2_applied.rhs, df)
     TΔ = modelcols(f1_applied.lhs, df)
-    return GeneralHazardModel(_method(GHM), TΔ[:,1], TΔ[:,2], _baseline(GHM), X1, X2)
+    return GeneralHazardModel(_method(GHM), TΔ[:,1], TΔ[:,2], _baseline(GHM), X1, X2;
+                              formula1 = f1_applied, formula2 = f2_applied)
 end
 function StatsBase.fit(::Type{GHM},
     formula::FormulaTerm,
@@ -236,20 +244,41 @@ function StatsBase.fit(::Type{GHM},
     f_applied = apply_schema(formula, sdf)
     X = modelcols(f_applied.rhs, df)
     TΔ = modelcols(f_applied.lhs, df)
-    # Use X for both X1 and X2 (PH, AFT, AH models will ignore one of them)
-    return GeneralHazardModel(_method(GHM), TΔ[:,1], TΔ[:,2], _baseline(GHM), X, X)
+    # Use X for both X1 and X2 (PH, AFT, AH models will ignore one of them).
+    # Both formulas are set to the same applied formula so predict-on-newdata
+    # works regardless of which method (PH/AFT/AH/GH) the user picked.
+    return GeneralHazardModel(_method(GHM), TΔ[:,1], TΔ[:,2], _baseline(GHM), X, X;
+                              formula1 = f_applied, formula2 = f_applied)
 end
 
-# Internal helper: return the per-subject (c1, c2) multipliers for any method.
-function _c1c2(m::GeneralHazardModel{M,B}) where {M,B}
+# Internal helper: return the per-subject (c1, c2) multipliers for any method,
+# given explicit design matrices. Used for both training (m.X1/m.X2) and newdata.
+function _c1c2(m::GeneralHazardModel{M,B}, X1, X2) where {M,B}
     method = M()
-    return c1(method, m.X1, m.X2, m.β, m.α), c2(method, m.X1, m.X2, m.β, m.α)
+    return c1(method, X1, X2, m.β, m.α), c2(method, X1, X2, m.β, m.α)
+end
+
+# Convenience overload for training data.
+_c1c2(m::GeneralHazardModel) = _c1c2(m, m.X1, m.X2)
+
+# Apply the fit's stored formulas to `newdata` and return `(X1_new, X2_new)`.
+# Errors if the model was constructed without stored formulas (e.g. via the
+# direct positional constructor without the kw `formula1` / `formula2`).
+function _build_X_for_newdata(m::GeneralHazardModel, newdata::DataFrame)
+    if isnothing(m.formula1) || isnothing(m.formula2)
+        error("This GeneralHazardModel was constructed without stored formulas; predict-on-newdata is not available. Re-fit via `fit(GHM, @formula(...), df)` (or the two-formula variant for `GeneralHazard`) so the formulas are captured.")
+    end
+    X1_new = modelcols(m.formula1.rhs, newdata)
+    X2_new = modelcols(m.formula2.rhs, newdata)
+    return X1_new, X2_new
 end
 
 """
     predict_expected(m::GeneralHazardModel)
     predict_expected(m::GeneralHazardModel, t::Real)
     predict_expected(m::GeneralHazardModel, ts::AbstractVector)
+    predict_expected(m::GeneralHazardModel, newdata::DataFrame, t::Real)
+    predict_expected(m::GeneralHazardModel, newdata::DataFrame, ts::AbstractVector)
 
 Per-subject cumulative hazard `Λᵢ(t) = H₀(t · c1ᵢ) · c2ᵢ`, where `H₀` is the cumulative
 hazard of the baseline distribution and `(c1ᵢ, c2ᵢ)` are the method-specific time- and
@@ -261,6 +290,11 @@ Output shape:
   observed time `Tᵢ`;
 - `t::Real` → length-`n` vector at the scalar time;
 - `ts::AbstractVector` → `n × length(ts)` matrix.
+
+With `newdata::DataFrame` the design matrices are rebuilt by applying the fit's stored
+formula(s) — `newdata` must contain every predictor column referenced in the original
+`@formula(...)`. Newdata predict requires an explicit time argument (no "own time"
+default).
 """
 function predict_expected(m::GeneralHazardModel)
     cc1, cc2 = _c1c2(m)
@@ -282,17 +316,39 @@ function predict_expected(m::GeneralHazardModel, ts::AbstractVector)
     return out
 end
 
+function predict_expected(m::GeneralHazardModel, newdata::DataFrame, t::Real)
+    X1_new, X2_new = _build_X_for_newdata(m, newdata)
+    cc1, cc2 = _c1c2(m, X1_new, X2_new)
+    return (-logccdf.(m.baseline, t .* cc1)) .* cc2
+end
+
+function predict_expected(m::GeneralHazardModel, newdata::DataFrame, ts::AbstractVector)
+    X1_new, X2_new = _build_X_for_newdata(m, newdata)
+    cc1, cc2 = _c1c2(m, X1_new, X2_new)
+    n = length(cc1)
+    out = Matrix{Float64}(undef, n, length(ts))
+    @inbounds for j in eachindex(ts)
+        out[:, j] = (-logccdf.(m.baseline, ts[j] .* cc1)) .* cc2
+    end
+    return out
+end
+
 """
     predict_survival(m::GeneralHazardModel)
     predict_survival(m::GeneralHazardModel, t::Real)
     predict_survival(m::GeneralHazardModel, ts::AbstractVector)
+    predict_survival(m::GeneralHazardModel, newdata::DataFrame, t::Real)
+    predict_survival(m::GeneralHazardModel, newdata::DataFrame, ts::AbstractVector)
 
 Per-subject survival probability `Sᵢ(t) = exp(-Λᵢ(t))` derived from
-[`predict_expected`](@ref). Shapes match `predict_expected`.
+[`predict_expected`](@ref). Shapes match `predict_expected`; newdata variants
+require an explicit time argument.
 """
 predict_survival(m::GeneralHazardModel)                     = exp.(-predict_expected(m))
 predict_survival(m::GeneralHazardModel, t::Real)            = exp.(-predict_expected(m, t))
 predict_survival(m::GeneralHazardModel, ts::AbstractVector) = exp.(-predict_expected(m, ts))
+predict_survival(m::GeneralHazardModel, newdata::DataFrame, t::Real)            = exp.(-predict_expected(m, newdata, t))
+predict_survival(m::GeneralHazardModel, newdata::DataFrame, ts::AbstractVector) = exp.(-predict_expected(m, newdata, ts))
 
 function StatsBase.predict(m::GeneralHazardModel, type::Symbol=:survival)
     type == :survival && return predict_survival(m)
@@ -310,6 +366,23 @@ function StatsBase.predict(m::GeneralHazardModel, type::Symbol, ts::AbstractVect
     type == :survival && return predict_survival(m, ts)
     type == :expected && return predict_expected(m, ts)
     error("Time-indexed `predict` on GeneralHazardModel supports `:survival` and `:expected`, got `:$type`.")
+end
+
+function StatsBase.predict(m::GeneralHazardModel, type::Symbol, newdata::DataFrame)
+    type in (:survival, :expected) && error("`:$type` on newdata requires a time argument: predict(m, :$type, newdata, t).")
+    error("Unsupported predict type `:$type` for GeneralHazardModel on newdata. Supported: `:survival`, `:expected` (with a time argument).")
+end
+
+function StatsBase.predict(m::GeneralHazardModel, type::Symbol, newdata::DataFrame, t::Real)
+    type == :survival && return predict_survival(m, newdata, t)
+    type == :expected && return predict_expected(m, newdata, t)
+    error("Time-indexed `predict` on GeneralHazardModel newdata supports `:survival` and `:expected`, got `:$type`.")
+end
+
+function StatsBase.predict(m::GeneralHazardModel, type::Symbol, newdata::DataFrame, ts::AbstractVector)
+    type == :survival && return predict_survival(m, newdata, ts)
+    type == :expected && return predict_expected(m, newdata, ts)
+    error("Time-indexed `predict` on GeneralHazardModel newdata supports `:survival` and `:expected`, got `:$type`.")
 end
 
 """

--- a/test/test.jl
+++ b/test/test.jl
@@ -708,3 +708,75 @@ end
         @test all(S_mat[:, j] .≈ S_mat[1, j])
     end
 end
+
+
+@testitem "GeneralHazardModel predict on newdata" begin
+    using DataFrames, Distributions, Random
+    using SurvivalModels: predict, ProportionalHazard, AcceleratedFaillureTime,
+                          AcceleratedHazard, GeneralHazard, GeneralHazardModel, PHMethod
+    using StableRNGs
+
+    rng = StableRNG(2024)
+    n   = 30
+    df  = DataFrame(
+        time   = rand(rng, Exponential(2.0), n),
+        status = rand(rng, Bool, n),
+        x1     = randn(rng, n),
+        x2     = randn(rng, n),
+    )
+
+    # Single-formula fits exercise PH/AFT/AH (all four are routed through the same
+    # internal path with both formulas set to the same applied formula).
+    single_formula_types = (
+        ProportionalHazard{Weibull},
+        AcceleratedFaillureTime{Weibull},
+        AcceleratedHazard{Weibull},
+    )
+    for T in single_formula_types
+        m = fit(T, @formula(Surv(time, status) ~ x1 + x2), df)
+
+        # Self-consistency: newdata-on-training matches the no-newdata path.
+        @test predict(m, :survival, df, 1.0)             ≈ predict(m, :survival, 1.0)             rtol = 1e-10
+        @test predict(m, :expected, df, 1.0)             ≈ predict(m, :expected, 1.0)             rtol = 1e-10
+        @test predict(m, :survival, df, [0.5, 1.0, 2.0]) ≈ predict(m, :survival, [0.5, 1.0, 2.0]) rtol = 1e-10
+
+        # Held-out slice shapes.
+        held = df[1:5, :]
+        @test size(predict(m, :survival, held, 1.0))             == (5,)
+        @test size(predict(m, :expected, held, 1.0))             == (5,)
+        @test size(predict(m, :survival, held, [0.5, 1.0, 2.0])) == (5, 3)
+        @test size(predict(m, :expected, held, [0.5, 1.0, 2.0])) == (5, 3)
+
+        # `S = exp(-H)` consistency on newdata.
+        @test predict(m, :survival, held, 1.0) ≈ exp.(-predict(m, :expected, held, 1.0)) rtol = 1e-12
+
+        # `S(t)` ∈ [0,1] and non-increasing in t on newdata.
+        S = predict(m, :survival, held, [0.5, 1.0, 2.0, 5.0])
+        @test all(0 .≤ S .≤ 1 .+ 1e-12)
+        @test all(diff(S, dims = 2) .≤ 1e-12)
+
+        # Newdata predict requires an explicit time argument.
+        @test_throws ErrorException predict(m, :survival, held)
+        @test_throws ErrorException predict(m, :expected, held)
+
+        # Unsupported types error.
+        @test_throws ErrorException predict(m, :lp, held, 1.0)
+    end
+
+    # Two-formula GH fit captures both formulas distinctly.
+    m_gh = fit(GeneralHazard{Weibull},
+               @formula(Surv(time, status) ~ x1 + x2),
+               @formula(Surv(time, status) ~ x1),
+               df)
+    @test predict(m_gh, :survival, df, 1.0) ≈ predict(m_gh, :survival, 1.0) rtol = 1e-10
+    @test size(predict(m_gh, :expected, df[1:5, :], [1.0, 2.0])) == (5, 2)
+
+    # Direct construction without formulas should error on newdata predict.
+    n2  = 20
+    T2  = rand(rng, Exponential(2.0), n2)
+    Δ2  = rand(rng, Bool, n2)
+    X12 = randn(rng, n2, 2)
+    X22 = randn(rng, n2, 2)
+    bare = ProportionalHazard(T2, Δ2, Weibull(1.0, 2.0), X12, X22, zeros(2), zeros(2))
+    @test_throws ErrorException predict(bare, :survival, df, 1.0)
+end


### PR DESCRIPTION
Mirrors #47 (Cox newdata predict) for `GeneralHazardModel`.

## Summary

`GeneralHazardModel` gains two optional fields:

```julia
formula1::Union{FormulaTerm, Nothing}
formula2::Union{FormulaTerm, Nothing}
```

Both `fit` paths pass the schema-applied formulas through kwargs:

- `fit(GHM, formula, df)` (single-formula — PH / AFT / AH): stores the same applied formula twice, so it can rebuild both `X1` and `X2` on newdata.
- `fit(GeneralHazard, formula1, formula2, df)` (two-formula — GH): stores them separately.

The direct positional constructors (e.g. `ProportionalHazard(T, Δ, baseline, X1, X2, α, β)`) leave the formula fields at their `nothing` defaults — backwards-compatible. Predict-on-newdata on such models errors with an explanatory message.

## API

```julia
predict_expected(m::GeneralHazardModel, newdata::DataFrame, t::Real)             # length-n_new
predict_expected(m::GeneralHazardModel, newdata::DataFrame, ts::AbstractVector)  # n_new × length(ts)
predict_survival(m::GeneralHazardModel, newdata::DataFrame, t::Real)
predict_survival(m::GeneralHazardModel, newdata::DataFrame, ts::AbstractVector)

predict(m, type, newdata, t)
predict(m, type, newdata, ts)
```

Newdata predict **requires** an explicit time argument — matches the Cox convention from #47. `:lp` / `:risk` / `:terms` remain absent for parametric (no canonical single linear predictor with two coefficient sets).

## Implementation

- `_c1c2(m)` generalised to `_c1c2(m, X1, X2)` so the unified `H(t | x) = H₀(t · c1) · c2` closed form powers both training and newdata predict. One-arg form is a thin wrapper over the training `X1`/`X2`.
- New `_build_X_for_newdata(m, newdata)` returns `(X1_new, X2_new)` by applying the stored formula(s)' schema to `newdata`.

## Tests

New `@testitem "GeneralHazardModel predict on newdata"`:

- Loops over PH / AFT / AH (single-formula fit path) and verifies for each: self-consistency (newdata-on-training matches no-newdata), held-out slice shapes for scalar and vector `t`, `S = exp(-H)`, `S ∈ [0,1]` and monotone non-increasing in `t`, no-time-on-newdata errors, `:lp` rejection on newdata.
- Separately covers the two-formula GH fit path.
- Verifies the direct-construction-without-formula error path.

Test count: 506 → 548.

## Docs

New "Predict on new data" subsection in `docs/src/parametric/generalhazard.md` listing the newdata signatures and the formula-storage / no-default-time conventions. Existing `@docs` blocks pick up the extended docstrings automatically (signature list in the multi-method docstring).

## Out of scope (follow-up)

- **Parametric Brier on newdata.** `brier_score` already accepts a generic `predicted_survival` vector. Adding `brier_score(m::GeneralHazardModel, newdata, t)` is a one-line addition once this PR lands.