### PR TITLE
[Parametric] Seed GHM optimizer from data (fixes #60)

### DIFF
--- a/src/Parametric/GeneralHazard.jl
+++ b/src/Parametric/GeneralHazard.jl
@@ -77,7 +77,7 @@ struct GeneralHazardModel{Method, B}
                                 formula1::Union{FormulaTerm, Nothing}=nothing,
                                 formula2::Union{FormulaTerm, Nothing}=nothing) where {Method<:AbstractGHMethod}
         npd, p, q = length(Distributions.params(baseline)), size(X1,2), size(X2,2)
-        init = zeros(npd+p+q)
+        init = vcat(_initial_baseline_log_params(baseline, T), zeros(p + q))
         base_T = typeof(baseline).name.wrapper
         Δ = Bool.(Δ)
         function mloglik(par::Vector)
@@ -99,6 +99,42 @@ end
 _method(::Type{GeneralHazardModel{M,B}}) where {M,B} = M()
 _baseline(::Type{GeneralHazardModel{M,B}}) where {M,B} = B()
 _method(::Type{GeneralHazardModel{M}}) where {M} = M()
+
+"""
+    _initial_baseline_log_params(baseline, T) -> Vector{Float64}
+
+Seed the optimizer's log-parameter vector for the baseline distribution
+of [`GeneralHazardModel`](@ref). For baselines where `Distributions.fit_mle`
+exists and returns strictly positive parameters on the (marginal) event
+times, use those as the seed; for the rest, anchor the last (conventionally
+scale-like) parameter to `log(median(T))` and leave the rest at `log(1) = 0`.
+
+The zeros-init this replaces puts e.g. `Weibull(1, 1)` on data with event
+times in 10²–10⁴, putting the log-likelihood in a NaN region and erroring
+out (or, before the NaN check, silently returning `β = 0`). See issue #60.
+
+Censoring is ignored for the seed — it's a starting point, not the final
+estimate. The joint optimizer subsequently refines `α`, `β`, and the
+baseline together.
+"""
+_initial_baseline_log_params(baseline::Distribution, T) = _scale_anchored_init(baseline, T)
+
+# Distributions.jl ships `fit_mle` for these four; on positive event-time
+# data the fitted params are all positive, so taking `log` is well-defined.
+_initial_baseline_log_params(::Weibull,     T) = _log_fit_params(Weibull,     T)
+_initial_baseline_log_params(::LogNormal,   T) = _log_fit_params(LogNormal,   T)
+_initial_baseline_log_params(::Normal,      T) = _log_fit_params(Normal,      T)
+_initial_baseline_log_params(::Exponential, T) = _log_fit_params(Exponential, T)
+
+_log_fit_params(B::Type{<:Distribution}, T) =
+    log.(collect(Float64, Distributions.params(Distributions.fit_mle(B, T))))
+
+function _scale_anchored_init(baseline::Distribution, T)
+    npd = length(Distributions.params(baseline))
+    init = zeros(npd)
+    npd > 0 && (init[npd] = log(median(T)))
+    return init
+end
 
 """
     ProportionalHazard(T, Δ, baseline, X1, X2)

--- a/test/test.jl
+++ b/test/test.jl
@@ -944,3 +944,43 @@ end
     bare = ProportionalHazard(T2, Δ2, Weibull(1.0, 2.0), X12, X22, zeros(2), zeros(2))
     @test_throws ErrorException predict(bare, :survival, df, 1.0)
 end
+
+@testitem "GeneralHazardModel converges on day-scale ovarian (issue #60)" begin
+    # Regression test: before the data-aware init, the optimizer was seeded at
+    # `zeros(npd + p + q)`, which puts the baseline at e.g. `Weibull(1, 1)`.
+    # On ovarian (`futime ~ 60..1227`), that init evaluates the log-likelihood
+    # in a NaN region and the fit errored out (or, before the explicit NaN
+    # check was added, silently returned β = 0). With the `fit_mle`-seeded
+    # init, the fit converges directly on the day-scale data — no manual
+    # `T ./ 1000` rescaling required.
+    using Distributions, RDatasets
+    using SurvivalModels: ProportionalHazard, AcceleratedFaillureTime
+
+    ovarian = dataset("survival", "ovarian")
+    ovarian.FUTime = Float64.(ovarian.FUTime)
+    ovarian.FUStat = Bool.(ovarian.FUStat)
+    f = @formula(Surv(FUTime, FUStat) ~ Age + ECOG_PS)
+
+    # PH Weibull: flexsurv's converged reference (verified externally) is
+    # β ≈ (0.1608, -0.1654).
+    m_ph = fit(ProportionalHazard{Weibull}, f, ovarian)
+    @test m_ph.β[1] ≈ 0.1608 atol = 1e-3
+    @test m_ph.β[2] ≈ -0.1654 atol = 1e-3
+    @test all(>(0), Distributions.params(m_ph.baseline))
+
+    # AFT Weibull also converges on raw-day TIME (was the failing path in
+    # PR #59's reference test, which scaled FUTime by 1/1000 as a workaround).
+    m_aft = fit(AcceleratedFaillureTime{Weibull}, f, ovarian)
+    @test all(isfinite, m_aft.β)
+    @test !all(iszero, m_aft.β)
+    @test all(>(0), Distributions.params(m_aft.baseline))
+
+    # Spot-check the four baselines our `_initial_baseline_log_params`
+    # overrides explicitly (Distributions.fit_mle exists + returns positive
+    # params on positive event-time data).
+    for B in (Weibull, LogNormal, Normal, Exponential)
+        m = fit(AcceleratedFaillureTime{B}, f, ovarian)
+        @test all(isfinite, m.β)
+        @test all(>(0), Distributions.params(m.baseline))
+    end
+end


### PR DESCRIPTION
Fixes #60.

`GeneralHazardModel`'s optimizer init was `zeros(npd + p + q)`, putting the baseline at e.g. `Weibull(1, 1)`. On real-scale event times (days, seconds) that init evaluates the log-likelihood in a NaN region — the explicit check at L90 then errors out, and before that check existed the fit silently returned `β = 0` and the baseline unmoved (the original failure mode in #60).

## Approach

Replace the constant init with data-aware seeding, dispatched on the baseline type:

```julia
_initial_baseline_log_params(baseline::Distribution, T) = _scale_anchored_init(baseline, T)
_initial_baseline_log_params(::Weibull,     T) = _log_fit_params(Weibull,     T)
_initial_baseline_log_params(::LogNormal,   T) = _log_fit_params(LogNormal,   T)
_initial_baseline_log_params(::Normal,      T) = _log_fit_params(Normal,      T)
_initial_baseline_log_params(::Exponential, T) = _log_fit_params(Exponential, T)
```

- For baselines where `Distributions.fit_mle` is defined and returns strictly positive parameters on positive event-time data (Weibull, LogNormal, Normal, Exponential), use the marginal MLE as the seed — ignoring censoring is fine for a starting point; the joint optimizer subsequently refines `α`, `β`, and the baseline together.
- For everything else (Logistic — `suffstats` not implemented in Distributions.jl; plus any distribution from SurvivalDistributions.jl etc.), fall back to anchoring the last (conventionally scale-like) parameter to `log(median(T))` and leaving the rest at `log(1) = 0`.

Dispatch on the baseline type rather than a runtime `try/catch` — each override is a single line and the structural intent ("we know `fit_mle` is defined for this type") lives in the methods table.

## Why the workaround in #59 is no longer needed

The parametric R cross-check in #59 currently rescales `FUTime` by `1/1000` to get LBFGS to converge from the zeros-init. With this PR, AFT Weibull (and the other three fit_mle-overridden baselines) converge directly on the day-scale data. #59 can be simplified once this lands.

## Test plan

- [x] `Pkg.test("SurvivalModels")` — 601 / 601 (+14 from the new regression testitem).
- [x] New testitem `GeneralHazardModel converges on day-scale ovarian (issue #60)`:
  - PH Weibull `β` on unscaled `survival::ovarian` matches flexsurv's converged reference values (`0.1608, -0.1654`).
  - AFT Weibull converges (no NaN error) on unscaled `FUTime`.
  - Spot-check the four explicitly-overridden baselines (Weibull, LogNormal, Normal, Exponential) all converge with finite `β` and positive baseline params.