### PR TITLE
[NonParametric] Add predict accessors for KaplanMeier

### DIFF
--- a/docs/src/nonparametric/kaplanmeier.md
+++ b/docs/src/nonparametric/kaplanmeier.md
@@ -88,10 +88,22 @@ ci = confint(km)
 first(ci, 5)  # show the first 5 rows
 ```
 
+## Predictions
+
+A fitted estimator exposes a `predict` interface mirroring the one used by `Cox` and `GeneralHazardModel`, so downstream code can dispatch uniformly. With no time argument the result has one entry per stored event/censor time (`km.t`); with a scalar or vector time argument the step-function is evaluated at those times.
+
+```@example 1
+predict(km, :survival)         # Ŝ at each km.t
+predict(km, :cumhazard)        # Ĥ at each km.t
+predict(km, :survival, 5.0)    # Ŝ(5)
+predict(km, :survival, [1.0, 5.0, 8.0])  # Ŝ at the given times
+```
+
 ## References
 
 ```@docs
 KaplanMeier
+predict(::KaplanMeier)
 greenwood
 ```
 

--- a/src/NonParametric/KaplanMeier.jl
+++ b/src/NonParametric/KaplanMeier.jl
@@ -104,6 +104,49 @@ end
 (S::KaplanMeier)(t) = prod((1 - S.∂Λ[i] for i in eachindex(S.t) if S.t[i] < t); init=1.0)
 
 """
+    predict(km::KaplanMeier)                       # = predict(km, :survival)
+    predict(km::KaplanMeier, type::Symbol)         # vector at km.t
+    predict(km::KaplanMeier, type::Symbol, t)      # scalar (step-function eval)
+    predict(km::KaplanMeier, type::Symbol, ts::AbstractVector)  # vector at ts
+
+Survival-function (`type = :survival`) or cumulative-hazard (`type =
+:cumhazard`) predictions from a fitted Kaplan-Meier estimator. With no
+time argument the result has one entry per stored event/censor time
+(`km.t`); with a scalar or vector time argument the result is the
+step-function evaluated at those times, matching R's
+`summary(survfit, times = ts)` convention.
+
+Mirrors the `predict(model, type, [t])` surface that `Cox` and
+`GeneralHazardModel` expose so downstream code can dispatch on
+`AbstractSurvivalModel`-style supertypes uniformly.
+"""
+StatsAPI.predict(km::KaplanMeier) = predict(km, :survival)
+
+function StatsAPI.predict(km::KaplanMeier, type::Symbol)
+    if type === :survival
+        return cumprod(1 .- km.∂Λ)
+    elseif type === :cumhazard
+        return cumsum(km.∂Λ)
+    else
+        error("Unsupported predict type `:$type` for KaplanMeier. Supported: `:survival`, `:cumhazard`.")
+    end
+end
+
+function StatsAPI.predict(km::KaplanMeier, type::Symbol, t::Real)
+    if type === :survival
+        return km(t)
+    elseif type === :cumhazard
+        return sum((km.∂Λ[i] for i in eachindex(km.t) if km.t[i] < t); init = 0.0)
+    else
+        error("Unsupported predict type `:$type` for KaplanMeier. Supported: `:survival`, `:cumhazard`.")
+    end
+end
+
+StatsAPI.predict(km::KaplanMeier, type::Symbol, ts::AbstractVector) =
+    [predict(km, type, t) for t in ts]
+
+
+"""
     greenwood(S::KaplanMeier, t)
 
 Compute the Greenwood variance estimate for the Kaplan-Meier survival estimator at time `t`.

--- a/test/test.jl
+++ b/test/test.jl
@@ -1040,3 +1040,51 @@ end
         @test all(>(0), Distributions.params(m.baseline))
     end
 end
+
+@testitem "KaplanMeier predict accessors (issue #65)" begin
+    using DataFrames, Distributions
+    using SurvivalModels: KaplanMeier
+
+    # Hand-computable fixture: 4 events at distinct times, no censoring.
+    # KM: S(t_i) = ∏ (1 - 1/Y_j) for j ≤ i. With Y = [4, 3, 2, 1], ∂N = [1,1,1,1]:
+    # S = (3/4) * (2/3) * (1/2) * (0/1) = [0.75, 0.5, 0.25, 0.0]
+    df = DataFrame(T = [10.0, 20.0, 30.0, 40.0], Δ = Bool[1, 1, 1, 1])
+    km = fit(KaplanMeier, @formula(Surv(T, Δ) ~ 1), df)
+
+    # 0-arg form == :survival
+    @test predict(km) ≈ [0.75, 0.5, 0.25, 0.0]
+    @test predict(km, :survival) ≈ [0.75, 0.5, 0.25, 0.0]
+
+    # cumhazard = cumsum(∂Λ) = cumsum([1/4, 1/3, 1/2, 1])
+    @test predict(km, :cumhazard) ≈ cumsum([1 / 4, 1 / 3, 1 / 2, 1.0])
+
+    # Scalar step-function eval. Matches the existing callable for :survival.
+    @test predict(km, :survival, 25.0) == km(25.0)
+    @test predict(km, :survival, 0.0)  == 1.0     # before any event
+    @test predict(km, :survival, 1000.0) ≈ 0.0    # after all events
+    @test predict(km, :survival, 15.0) ≈ 0.75     # after t=10, before t=20
+
+    # Vector form
+    @test predict(km, :survival, [5.0, 15.0, 25.0, 35.0]) ≈ [1.0, 0.75, 0.5, 0.25]
+    @test predict(km, :cumhazard, [5.0, 15.0]) ≈ [0.0, 0.25]
+
+    # Unsupported type errors cleanly.
+    @test_throws ErrorException predict(km, :lp)
+    @test_throws ErrorException predict(km, :lp, 5.0)
+end
+
+@testitem "KaplanMeier predict matches R survfit on ovarian" begin
+    using Distributions, RDatasets
+    using SurvivalModels: KaplanMeier
+
+    # Reference values from R `summary(survfit(Surv(futime, fustat) ~ 1, data =
+    # survival::ovarian), times = c(100, 500, 1000))$surv`.
+    ovarian = dataset("survival", "ovarian")
+    ovarian.FUTime = Float64.(ovarian.FUTime)
+    ovarian.FUStat = Bool.(ovarian.FUStat)
+    km = fit(KaplanMeier, @formula(Surv(FUTime, FUStat) ~ 1), ovarian)
+    S = predict(km, :survival, [100.0, 500.0, 1000.0])
+    @test S[1] ≈ 0.961538461538462 atol = 1e-12
+    @test S[2] ≈ 0.596078431372549 atol = 1e-12
+    @test S[3] ≈ 0.496732026143791 atol = 1e-12
+end


### PR DESCRIPTION
Fixes #65.

`KaplanMeier` previously exposed the discrete-hazard components (`t`, `∂N`, `Y`, `∂Λ`, `∂σ`) but no `predict` interface, so downstream consumers had to reconstruct `S(t)` and `H(t)` from those fields by hand — and the `Cox` / `GeneralHazardModel` paths already expose `predict(model, type, t)`.

## API

```julia
predict(km::KaplanMeier)                              # = predict(km, :survival)
predict(km::KaplanMeier, type::Symbol)                # vector at km.t
predict(km::KaplanMeier, type::Symbol, t::Real)       # scalar step eval
predict(km::KaplanMeier, type::Symbol, ts::AbstractVector)  # vector at ts
```

Supported types: `:survival` (cumulative product of `1 - ∂Λ`) and `:cumhazard` (cumulative sum of `∂Λ`). The scalar step-function eval delegates to the existing `(S::KaplanMeier)(t)` callable for `:survival`; the vector form maps over the scalar.

## Test plan

- [x] `Pkg.test("SurvivalModels")` — 622 / 622 (+11 from the two new testitems).
- Hand-computable 4-event fixture pins exact values for both types and the scalar / vector / no-arg forms.
- `ovarian` cross-check pins three survival probabilities against `summary(survfit(Surv(futime, fustat) ~ 1, data = survival::ovarian), times = c(100, 500, 1000))$surv` to `atol = 1e-12`.