### PR TITLE
Add fit statistics (loglikelihood/aic/bic, coef/vcov/stderror) to GeneralHazardModel

### DIFF
--- a/docs/src/parametric/generalhazard.md
+++ b/docs/src/parametric/generalhazard.md
@@ -170,6 +170,18 @@ SurvivalModels.predict_expected(::SurvivalModels.GeneralHazardModel)
 SurvivalModels.predict_survival(::SurvivalModels.GeneralHazardModel)
 ```
 
+### Fit statistics
+
+`GeneralHazardModel <: StatsAPI.StatisticalModel`, so a fitted model supports the standard statistical-model accessors. `aic`, `aicc`, and `bic` follow from `loglikelihood`, `dof`, and `nobs`; `stderror` follows from `vcov`. `coef` and `vcov` are reported on the inference scale `[log.(baseline parameters); active regression coefficients]`, so `MvNormal(coef(m), vcov(m))` is a coherent parameter-uncertainty distribution.
+
+```@docs
+SurvivalModels.loglikelihood(::SurvivalModels.GeneralHazardModel)
+SurvivalModels.nobs(::SurvivalModels.GeneralHazardModel)
+SurvivalModels.dof(::SurvivalModels.GeneralHazardModel)
+SurvivalModels.coef(::SurvivalModels.GeneralHazardModel)
+SurvivalModels.vcov(::SurvivalModels.GeneralHazardModel)
+```
+
 #### Brier score
 
 Inverse-probability-of-censoring-weighted Brier score (Graf et al. 1999) and its integrated form work for `GeneralHazardModel` through the same `brier_score(model, ...)` / `integrated_brier_score(model, ...)` API used for Cox. See the [Model Evaluation: Brier Score](@ref) section of the Cox documentation for the mathematical definition and signature list.

--- a/src/Parametric/GeneralHazard.jl
+++ b/src/Parametric/GeneralHazard.jl
@@ -14,6 +14,21 @@ c2(::PHMethod,  X1, X2, β, α) = exp.(X1 * β)
 c2(::AFTMethod, X1, X2, β, α) = ones(size(X1, 1))
 c2(::AHMethod,  X1, X2, β, α) = exp.(-X2 * α)
 
+# Negative log-likelihood, parameterized by the flat vector
+# `par = [log-baseline params (1:npd); α (npd .+ 1:q); β (npd+q .+ 1:p)]`. The
+# fit wraps this in a small closure to optimize; `vcov` differentiates it again
+# at the optimum to form the observed information — one definition, two callers.
+function _neg_loglik(par, method::AbstractGHMethod, base_T, npd, T, Δ, X1, X2)
+    q, p = size(X2, 2), size(X1, 2)
+    d = base_T(exp.(par[1:npd])...)
+    α = par[npd .+ (1:q)]
+    β = par[npd + q .+ (1:p)]
+    B = (method isa AHMethod) ? 0.0 : (X1[Δ, :] * β)
+    C = c1(method, X1, X2, β, α)
+    D = c2(method, X1, X2, β, α)
+    return -sum(loghazard.(d, T[Δ] .* C[Δ]) .+ B) + sum(cumhazard.(d, T .* C) .* D)
+end
+
 """
     GeneralHazardModel{Method, B}
 
@@ -47,7 +62,7 @@ Supported methods:
 - `AcceleratedHazard`: For AH models.
 - `GeneralHazard`: For full GH models.
 """
-struct GeneralHazardModel{Method, B}
+struct GeneralHazardModel{Method, B} <: StatsAPI.StatisticalModel
     T::Vector{Float64}
     Δ::Vector{Bool}
     baseline::B
@@ -57,6 +72,11 @@ struct GeneralHazardModel{Method, B}
     β::Vector{Float64}
     formula1::Union{FormulaTerm, Nothing}
     formula2::Union{FormulaTerm, Nothing}
+    # Maximized log-likelihood at the fitted parameters, captured directly from
+    # the optimizer (the fit *is* the maximization of this quantity, so there is
+    # nothing to recompute). `NaN` for models built by the direct constructor,
+    # which performs no optimization. Consumed by `loglikelihood`/`aic`/`bic`.
+    loglik::Float64
 
     # Direct constructor: all parameters provided, no optimization
     function GeneralHazardModel(::Method, T, Δ, baseline::B, X1, X2, α, β;
@@ -68,7 +88,7 @@ struct GeneralHazardModel{Method, B}
             collect(T), Bool.(Δ), baseline,
             Matrix{Float64}(X1), Matrix{Float64}(X2),
             collect(α), collect(β),
-            formula1, formula2,
+            formula1, formula2, NaN,
         )
     end
 
@@ -80,25 +100,107 @@ struct GeneralHazardModel{Method, B}
         init = vcat(_initial_baseline_log_params(baseline, T), zeros(p + q))
         base_T = typeof(baseline).name.wrapper
         Δ = Bool.(Δ)
-        function mloglik(par::Vector)
-            d, α, β = base_T(exp.(par[1:npd])...), par[npd .+ (1:q)], par[npd + q .+ (1:p)]
-            B = (Method == AHMethod) ? 0.0 : (X1[Δ,:] * β)
-            C = c1(m, X1, X2, β, α)
-            D = c2(m, X1, X2, β, α)
-            return  -sum(loghazard.(d, T[Δ] .* C[Δ]) .+ B) + sum(cumhazard.(d, T .* C) .* D)
-        end
+        mloglik(par) = _neg_loglik(par, m, base_T, npd, T, Δ, X1, X2)
         if isnan(mloglik(init))
             error("Initial parameters lead to NaN in log-likelihood. Check your baseline distribution and initial values.")
         end
-        par = optimize(mloglik, init, method=LBFGS()).minimizer
+        res = optimize(mloglik, init, method=LBFGS())
+        par = res.minimizer
+        # `mloglik` is the negative log-likelihood, so the optimizer's minimum is
+        # exactly `-loglik` at the optimum — cache it rather than recomputing.
+        loglik = -res.minimum
         d, α, β = base_T(exp.(par[1:npd])...), par[npd .+ (1:q)], par[npd + q .+ (1:p)]
-        return new{Method, typeof(d)}(T, Δ, d, X1, X2, α, β, formula1, formula2)
+        return new{Method, typeof(d)}(T, Δ, d, X1, X2, α, β, formula1, formula2, loglik)
     end
 end
+
+# Indices of the identified regression coefficients within the concatenated
+# coefficient vector `[α (1:q); β (q .+ 1:p)]`, where `p = length(β)` (cols of
+# `X1`) and `q = length(α)` (cols of `X2`). Per the `c1`/`c2` table above, PH/AFT
+# identify only `β`, AH only `α`, GH both. In the single-formula fit `X2 == X1`,
+# so the inactive block is carried but not identified — it must be excluded from
+# `dof` (else AIC/BIC inflate) and from the Hessian (else it is singular).
+#
+# This is the single source of truth for "which parameters are active": `dof`,
+# the `vcov` Hessian slice, and `coef` all derive from it.
+_active_coef_idx(::PHMethod,  p, q) = (q + 1):(q + p)
+_active_coef_idx(::AFTMethod, p, q) = (q + 1):(q + p)
+_active_coef_idx(::AHMethod,  p, q) = 1:q
+_active_coef_idx(::GHMethod,  p, q) = 1:(q + p)
 
 _method(::Type{GeneralHazardModel{M,B}}) where {M,B} = M()
 _baseline(::Type{GeneralHazardModel{M,B}}) where {M,B} = B()
 _method(::Type{GeneralHazardModel{M}}) where {M} = M()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StatsAPI fit statistics
+#
+# `GeneralHazardModel <: StatisticalModel`, so once `loglikelihood`, `dof`, and
+# `nobs` are defined the generic `aic`/`aicc`/`bic` from StatsAPI work directly.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    loglikelihood(m::GeneralHazardModel)
+
+Maximized log-likelihood of the fitted model, captured from the optimizer at fit
+time (`NaN` for models built by the direct, non-optimizing constructor).
+"""
+StatsAPI.loglikelihood(m::GeneralHazardModel) = m.loglik
+
+"""
+    nobs(m::GeneralHazardModel)
+
+Number of observations (event/censoring times) the model was fit to.
+"""
+StatsAPI.nobs(m::GeneralHazardModel) = length(m.T)
+
+"""
+    dof(m::GeneralHazardModel)
+
+Number of free parameters consumed by the fit: the baseline distribution's
+parameters plus the regression coefficients that actually enter the hazard for
+this model's structure (`β` for PH/AFT, `α` for AH, both for GH).
+"""
+StatsAPI.dof(m::GeneralHazardModel{M}) where {M} =
+    length(Distributions.params(m.baseline)) +
+    length(_active_coef_idx(M(), size(m.X1, 2), size(m.X2, 2)))
+
+"""
+    coef(m::GeneralHazardModel)
+
+Identified parameters on the scale used for inference:
+`[log.(baseline parameters); active regression coefficients]`, where the active
+coefficients are `β` (PH/AFT), `α` (AH), or `[α; β]` (GH). This ordering matches
+[`vcov`](@ref), so `MvNormal(coef(m), vcov(m))` is a coherent sampling
+distribution for the parameter uncertainty (exponentiate the baseline entries to
+recover the natural-scale baseline parameters).
+"""
+function StatsAPI.coef(m::GeneralHazardModel{M}) where {M}
+    logθ = log.(collect(Float64, Distributions.params(m.baseline)))
+    coefs = vcat(m.α, m.β)[_active_coef_idx(M(), length(m.β), length(m.α))]
+    return vcat(logθ, coefs)
+end
+
+"""
+    vcov(m::GeneralHazardModel)
+
+Covariance of [`coef`](@ref): the inverse observed information, i.e. the inverse
+of the Hessian of the fitted negative log-likelihood at the optimum, restricted
+to the identified parameters (the inactive coefficient block makes the full
+Hessian singular). Computed on demand — LBFGS never forms the Hessian during the
+fit, so there is nothing cached to reuse. `stderror` follows from this via the
+generic `StatisticalModel` method.
+"""
+function StatsAPI.vcov(m::GeneralHazardModel{Method,B}) where {Method,B}
+    base_T = B.name.wrapper
+    npd = length(Distributions.params(m.baseline))
+    p, q = length(m.β), length(m.α)
+    par = vcat(log.(collect(Float64, Distributions.params(m.baseline))), m.α, m.β)
+    nll(θ) = _neg_loglik(θ, Method(), base_T, npd, m.T, m.Δ, m.X1, m.X2)
+    H = ForwardDiff.hessian(nll, par)
+    idx = vcat(1:npd, npd .+ _active_coef_idx(Method(), p, q))
+    return inv(H[idx, idx])
+end
 
 """
     _initial_baseline_log_params(baseline, T) -> Vector{Float64}

--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -90,7 +90,7 @@ include("Cox/CoxApprox.jl")
 # Extract the matrix of X's : 
 getX(M::CoxMethod) = M.X
 getX(M::CoxDefault) = M.Xᵗ'
-nobs(M::CoxMethod) = size(getX(M),1) # Default to X being (n,m)
+StatsAPI.nobs(M::CoxMethod) = size(getX(M),1) # Default to X being (n,m)
 nvar(M::CoxMethod) = size(getX(M),2)
 get_perm(M::CoxMethod) = M.o
 get_og_X(M::CoxMethod) = getX(M)[sortperm(get_perm(M)), :]

--- a/src/SurvivalModels.jl
+++ b/src/SurvivalModels.jl
@@ -13,6 +13,6 @@ include("Semiparametric/Cox.jl")
 include("Parametric/GeneralHazard.jl")
 include("Metrics/BrierScore.jl")
 
-export fit, predict, KaplanMeier, LogRankTest, Cox, @formula, Surv, Strata, confint, GeneralHazard, ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, simGH, loss
+export fit, predict, KaplanMeier, LogRankTest, Cox, @formula, Surv, Strata, confint, GeneralHazard, ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, simGH, loss, loglikelihood, aic, aicc, bic, dof, nobs, coef, vcov, stderror
 
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -1088,3 +1088,59 @@ end
     @test S[2] ≈ 0.596078431372549 atol = 1e-12
     @test S[3] ≈ 0.496732026143791 atol = 1e-12
 end
+
+@testitem "GeneralHazardModel fit statistics (loglikelihood/aic/bic/coef/vcov)" begin
+    using DataFrames, Distributions, LinearAlgebra
+    using SurvivalModels: ProportionalHazard, AcceleratedFaillureTime,
+                          AcceleratedHazard, GeneralHazard
+    using StableRNGs
+
+    rng = StableRNG(20250101)
+    n   = 300
+    z   = randn(rng, n); w = randn(rng, n)
+    η   = 0.6 .* z .- 0.3 .* w
+    T   = 5.0 .* (-log.(rand(rng, n)) .* exp.(-η)) .^ (1 / 1.2)
+    C   = rand(rng, n) .* 20.0
+    df  = DataFrame(time = min.(T, C), status = T .<= C, z = z, w = w)
+
+    m = fit(ProportionalHazard{Weibull}, @formula(Surv(time, status) ~ z + w), df)
+
+    # Core statistics are finite and internally consistent.
+    @test isfinite(loglikelihood(m))
+    @test nobs(m) == n
+    @test dof(m) == 4                       # Weibull shape + scale + 2 PH coefs
+    @test aic(m)  ≈ -2 * loglikelihood(m) + 2 * dof(m)
+    @test bic(m)  ≈ -2 * loglikelihood(m) + dof(m) * log(nobs(m))
+    @test aicc(m) ≈ aic(m) + 2 * dof(m) * (dof(m) + 1) / (nobs(m) - dof(m) - 1)
+
+    # coef is on the inference scale [log(baseline params); active coefs], matching vcov.
+    c = coef(m)
+    @test length(c) == dof(m) == 4
+    @test exp.(c[1:2]) ≈ collect(params(m.baseline))   # baseline params recovered
+    @test c[3:4] ≈ m.β                                  # PH active coefs are β
+
+    # vcov: symmetric positive-definite dof×dof; stderror = sqrt.(diag(vcov)).
+    V = vcov(m)
+    @test size(V) == (4, 4)
+    @test isapprox(V, V')
+    @test isposdef(Symmetric(V))
+    @test stderror(m) ≈ sqrt.(diag(V))
+    @test all(isfinite, stderror(m))
+
+    # dof counts only the identified coefficients for each hazard structure.
+    me = fit(ProportionalHazard{Exponential}, @formula(Surv(time, status) ~ z + w), df)
+    @test dof(me) == 3                      # Exponential scale + 2 PH coefs
+    @test length(coef(me)) == 3 && size(vcov(me)) == (3, 3)
+
+    # Per-method dof via the direct constructor (no optimization needed): PH/AFT
+    # identify β, AH identifies α, GH both.
+    X1 = hcat(z, w); X2 = hcat(z, w)
+    base = Weibull(1.5, 5.0)
+    @test dof(ProportionalHazard(T, df.status, base, X1, X2, zeros(2), zeros(2)))     == 4
+    @test dof(AcceleratedFaillureTime(T, df.status, base, X1, X2, zeros(2), zeros(2))) == 4
+    @test dof(AcceleratedHazard(T, df.status, base, X1, X2, zeros(2), zeros(2)))       == 4
+    @test dof(GeneralHazard(T, df.status, base, X1, X2, zeros(2), zeros(2)))           == 6
+
+    # The direct (non-optimizing) constructor reports loglik = NaN.
+    @test isnan(loglikelihood(ProportionalHazard(T, df.status, base, X1, X2, zeros(2), zeros(2))))
+end


### PR DESCRIPTION
Makes `GeneralHazardModel` a `StatsAPI.StatisticalModel` and implements the standard fit-statistics API for the parametric (PH/AFT/AH/GH) models, with documentation and tests.

### Added API
- `loglikelihood` — the maximized log-likelihood, cached from the optimizer result at fit time (the fit *is* its maximization, so nothing is recomputed).
- `dof` / `nobs` — and therefore `aic`/`aicc`/`bic` for free from the `StatisticalModel` generics.
- `coef` — identified parameters on the inference scale `[log.(baseline params); active coefs]`.
- `vcov` — observed information computed on demand (inverse Hessian of the same negative log-likelihood the optimizer minimized), restricted to the identified block; `stderror` then follows from the generic `StatisticalModel` method.

These are exported from `SurvivalModels`.

### Notes
- `dof` counts only the coefficients that actually enter the hazard for each structure (`β` for PH/AFT, `α` for AH, both for GH). In the single-formula fit `X2 == X1`, so the unused coefficient block is carried but not identified — counting it would inflate AIC/BIC and make the full Hessian singular, so it is excluded from both `dof` and `vcov`.
- The negative log-likelihood is factored into one `_neg_loglik` function: the fit wraps it in a thin closure and `vcov` differentiates it again, so the optimizer and the inference Hessian share a single objective (benchmarked: no extra per-call allocation vs. the previous inline closure).
- `Cox`'s `nobs` now extends `StatsAPI.nobs` rather than defining a shadowing function, so the package's `nobs` is unambiguous alongside `StatsBase`.

### Docs & tests
- New "Fit statistics" section in `docs/src/parametric/generalhazard.md` documenting the five accessors (resolves the strict `missing_docs` doc build).
- New testitem covering `loglikelihood`/`aic`/`aicc`/`bic`/`dof`/`nobs`/`coef`/`vcov`/`stderror`: the AIC/BIC/AICc identities, `coef`↔`vcov` ordering, an SPD `vcov`, per-method `dof` (PH/AFT/AH/GH), and `loglik = NaN` from the direct constructor.

### Commits
- Add fit statistics + coef/vcov/stderror to GeneralHazardModel
- docs: document GeneralHazardModel fit statistics
- test: cover GeneralHazardModel fit statistics
