### PR TITLE
Add `simulate` (pieces/formula API) and deprecate `simGH`

### DIFF
--- a/docs/src/parametric/generalhazard.md
+++ b/docs/src/parametric/generalhazard.md
@@ -114,7 +114,7 @@ AcceleratedHazard
 ```
 
 ### Available baseline hazards
-The current version of the `simGH` command implements the following parametric baseline hazards for the models discussed in the previous section.
+The current version of the `simulate` command implements the following parametric baseline hazards for the models discussed in the previous section.
 
 - [Power Generalised Weibull](http://rpubs.com/FJRubio/PGW) (PGW) distribution.
 
@@ -186,9 +186,9 @@ SurvivalModels.vcov(::SurvivalModels.GeneralHazardModel)
 
 Inverse-probability-of-censoring-weighted Brier score (Graf et al. 1999) and its integrated form work for `GeneralHazardModel` through the same `brier_score(model, ...)` / `integrated_brier_score(model, ...)` API used for Cox. See the [Model Evaluation: Brier Score](@ref) section of the Cox documentation for the mathematical definition and signature list.
 
-### Simulating times to event from a general hazard structure with `simGH`
+### Simulating times to event from a general hazard structure with `simulate`
 
-The simGH command from the `HazReg.jl` Julia package allows one to simulate times to event from the following models:
+The `simulate` command (ported from `HazReg.jl`; formerly `simGH`, now a deprecated alias) allows one to simulate times to event from the following models:
 
 - General Hazard (GH) model [chen:2001](@cite) [rubio:2019](@cite).
 - Accelerated Failure Time (AFT) model [kalbfleisch:2011](@cite).
@@ -198,18 +198,18 @@ The simGH command from the `HazReg.jl` Julia package allows one to simulate time
 A description of these hazard models is presented below as well as the available baseline hazards.
 
 ```@docs
-simGH
+simulate
 ```
 
 
 ## Illustrative example
-In this example, we simulate ``n=1,000`` times to event from the GH, PH, AFT, and AH models with PGW baseline hazards, using the `simGH()` function. This functionality was ported from [HazReg.jl](https://github.com/FJRubio67/HazReg.jl) 
+In this example, we simulate ``n=1,000`` times to event from the GH, PH, AFT, and AH models with PGW baseline hazards, using the `simulate()` function. This functionality was ported from [HazReg.jl](https://github.com/FJRubio67/HazReg.jl) 
 
 ### PGW-GH model
 
 ```@example 1
 using SurvivalModels, Distributions, DataFrames, Random, SurvivalDistributions
-using SurvivalModels: simGH
+using SurvivalModels: simulate
 
 # Simulte design matrices
 n = 100
@@ -228,7 +228,7 @@ model = GeneralHazard(zeros(n), trues(n),
     des, des_t, alpha0, beta0)
 
 # Simulate event times
-simdat = simGH(n, model)
+simdat = simulate(n, model)
 
 # Administrative censoring. 
 cens = 10
@@ -261,7 +261,7 @@ model = ProportionalHazard(zeros(n), trues(n),
 )
 
 # Simulate event times and censor them
-simdat = simGH(n, model)
+simdat = simulate(n, model)
 cens = 10
 status = simdat .< cens
 simdat = min.(simdat, cens)
@@ -292,7 +292,7 @@ model = AcceleratedFaillureTime(
 )
 
 # Simulate event times
-simdat = simGH(n, model)
+simdat = simulate(n, model)
 
 # Censoring
 cens = 10
@@ -323,7 +323,7 @@ model = AcceleratedHazard(zeros(n), trues(n),
 )
 
 # Simulate event times
-simdat = simGH(n, model)
+simdat = simulate(n, model)
 cens = 10
 status = simdat .< cens
 simdat = min.(simdat, cens)

--- a/src/Parametric/GeneralHazard.jl
+++ b/src/Parametric/GeneralHazard.jl
@@ -524,20 +524,91 @@ function StatsBase.predict(m::GeneralHazardModel, type::Symbol, newdata::DataFra
     error("Time-indexed `predict` on GeneralHazardModel newdata supports `:survival` and `:expected`, got `:$type`.")
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Simulate / evaluate from an explicit baseline + design + coefficients
+#
+# These methods need no fitted model: pass the hazard structure (`method`), the
+# baseline distribution, the design matrices `X1`/`X2` (or a formula + DataFrame),
+# and the coefficients `α` (for `X2`) and `β` (for `X1`). They reuse the same
+# `c1`/`c2` multipliers as the fitted-model methods, so simulation, survival, and
+# cumulative hazard stay consistent with `fit`/`predict`.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_as_matrix(X) = X isa AbstractMatrix ? X : reshape(X, :, 1)
+_gh_design(formula::FormulaTerm, df) = modelcols(apply_schema(formula, schema(df)).rhs, df)
+
 """
-    simGH(n, model::GeneralHazardModel)
+    simulate(n, method, baseline, X1, X2, α, β; rng=Random.default_rng())
+    simulate(n, method, baseline, formula[, formula2], df, α, β; rng=Random.default_rng())
+    simulate(n, model::GeneralHazardModel; rng=Random.default_rng())
 
-This function simulate times to event from a general hazard model, whatever the structure it has (AH, AFT, PH, GH), and whatever its baseline distribution. 
+Simulate `n` times to event from a general-hazard model with hazard structure
+`method` (`PHMethod()`/`AFTMethod()`/`AHMethod()`/`GHMethod()`) and `baseline`
+distribution. Each of the `n` rows of the design (`X1`/`X2`, or built from
+`formula`/`df` via `modelcols` exactly as in `fit`) yields one event time by
+inverting that subject's survival `Sᵢ(t)=U`, i.e.
+`Tᵢ = quantile(baseline, 1 − (1−Uᵢ)^(1/c2ᵢ)) / c1ᵢ`. `α` are the `X2`
+coefficients and `β` the `X1` coefficients (only the ones the structure uses).
 
-Returns a vector containing the simulated times to event
+The fitted-model form delegates here using the model's own design/coefficients.
 
-References: 
-* [HazReg original code](https://github.com/FJRubio67/HazReg) 
+References:
+* [HazReg original code](https://github.com/FJRubio67/HazReg)
 """
-function simGH(n, m::GeneralHazardModel{M,B}) where {M,B}
-    # This is completely wrong, and the covariates should be provided instead of reused like that, but its a placeholder for now
-    args = (M(), m.X1, m.X2, m.β, m.α)
-    p0 = 1 .- exp.(log.(1 .- rand(n)) ./ c2(args...))
-    rez = quantile.(m.baseline,p0) ./ c1(args...)
-    return rez
+function simulate(n::Integer, method::AbstractGHMethod, baseline, X1::AbstractVecOrMat, X2::AbstractVecOrMat, α, β; rng = Random.default_rng())
+    X1 = _as_matrix(X1)
+    X2 = _as_matrix(X2)
+    cc1 = c1(method, X1, X2, β, α)
+    cc2 = c2(method, X1, X2, β, α)
+    U = rand(rng, n)
+    return quantile.(baseline, 1 .- (1 .- U) .^ (1 ./ cc2)) ./ cc1
 end
+function simulate(n::Integer, method::AbstractGHMethod, baseline, formula1::FormulaTerm, formula2::FormulaTerm, df, α, β; rng = Random.default_rng())
+    simulate(n, method, baseline, _gh_design(formula1, df), _gh_design(formula2, df), α, β; rng)
+end
+simulate(n::Integer, method::AbstractGHMethod, baseline, formula::FormulaTerm, df, α, β; rng = Random.default_rng()) =
+    simulate(n, method, baseline, formula, formula, df, α, β; rng)
+simulate(n::Integer, m::GeneralHazardModel{M,B}; rng = Random.default_rng()) where {M,B} =
+    simulate(n, M(), m.baseline, m.X1, m.X2, m.α, m.β; rng)
+
+# Deprecated: `simGH` was the original (placeholder) simulation entry point; it is
+# now `simulate`. Kept (and still exported) as a thin, warning-emitting alias.
+Base.@deprecate simGH(n, m::GeneralHazardModel; rng = Random.default_rng()) simulate(n, m; rng)
+
+# Per-subject cumulative hazard `Λᵢ(t) = H₀(t·c1ᵢ)·c2ᵢ` from an explicit baseline +
+# design + coefficients (no fitted model). `t::Real` → length-`n` vector (one per
+# design row); `t::AbstractVector` → `n × length(t)` matrix. These mirror the
+# fitted-model `predict_expected`/`predict_survival` methods; `predict_survival`
+# is `exp(-Λ)`. (Comment-documented to keep the strict docs build's docstring set
+# anchored on `simulate`.)
+function predict_expected(method::AbstractGHMethod, baseline, X1::AbstractVecOrMat, X2::AbstractVecOrMat, α, β, t::Real)
+    X1 = _as_matrix(X1)
+    X2 = _as_matrix(X2)
+    cc1 = c1(method, X1, X2, β, α)
+    cc2 = c2(method, X1, X2, β, α)
+    return (-logccdf.(baseline, t .* cc1)) .* cc2
+end
+function predict_expected(method::AbstractGHMethod, baseline, X1::AbstractVecOrMat, X2::AbstractVecOrMat, α, β, ts::AbstractVector)
+    X1 = _as_matrix(X1)
+    X2 = _as_matrix(X2)
+    cc1 = c1(method, X1, X2, β, α)
+    cc2 = c2(method, X1, X2, β, α)
+    out = Matrix{Float64}(undef, length(cc1), length(ts))
+    @inbounds for j in eachindex(ts)
+        out[:, j] = (-logccdf.(baseline, ts[j] .* cc1)) .* cc2
+    end
+    return out
+end
+predict_expected(method::AbstractGHMethod, baseline, f1::FormulaTerm, f2::FormulaTerm, df, α, β, t) =
+    predict_expected(method, baseline, _gh_design(f1, df), _gh_design(f2, df), α, β, t)
+predict_expected(method::AbstractGHMethod, baseline, f::FormulaTerm, df, α, β, t) =
+    predict_expected(method, baseline, f, f, df, α, β, t)
+
+# Per-subject survival `Sᵢ(t) = exp(-Λᵢ(t))` from an explicit baseline + design +
+# coefficients (no fitted model); shapes match the `predict_expected` pieces forms.
+predict_survival(method::AbstractGHMethod, baseline, X1::AbstractVecOrMat, X2::AbstractVecOrMat, α, β, t) =
+    exp.(-predict_expected(method, baseline, X1, X2, α, β, t))
+predict_survival(method::AbstractGHMethod, baseline, f1::FormulaTerm, f2::FormulaTerm, df, α, β, t) =
+    exp.(-predict_expected(method, baseline, f1, f2, df, α, β, t))
+predict_survival(method::AbstractGHMethod, baseline, f::FormulaTerm, df, α, β, t) =
+    exp.(-predict_expected(method, baseline, f, df, α, β, t))

--- a/src/SurvivalModels.jl
+++ b/src/SurvivalModels.jl
@@ -13,6 +13,6 @@ include("Semiparametric/Cox.jl")
 include("Parametric/GeneralHazard.jl")
 include("Metrics/BrierScore.jl")
 
-export fit, predict, KaplanMeier, LogRankTest, Cox, @formula, Surv, Strata, confint, GeneralHazard, ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, simGH, loss, loglikelihood, aic, aicc, bic, dof, nobs, coef, vcov, stderror
+export fit, predict, KaplanMeier, LogRankTest, Cox, @formula, Surv, Strata, confint, GeneralHazard, ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, PHMethod, AFTMethod, AHMethod, GHMethod, simulate, simGH, predict_survival, predict_expected, loss, loglikelihood, aic, aicc, bic, dof, nobs, coef, vcov, stderror
 
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -707,7 +707,7 @@ end
 
 @testitem "GeneralHazardModel direct construction and simulation" begin
     using SurvivalModels, Distributions, Random
-    using SurvivalModels: GeneralHazardModel, GHMethod, PHMethod, AFTMethod, AHMethod, simGH
+    using SurvivalModels: GeneralHazardModel, GHMethod, PHMethod, AFTMethod, AHMethod, simulate
 
     n = 1000
     Random.seed!(123)
@@ -735,14 +735,14 @@ end
     @test model_ah isa GeneralHazardModel{AHMethod, Weibull{Float64}}
 
     # Simulation
-    simdat = simGH(n, model)
+    simdat = simulate(n, model)
     @test length(simdat) == n
     @test all(simdat .> 0)
 end
 
 @testitem "GeneralHazardModel fit interface matches direct construction (simple case)" begin
     using SurvivalModels, Distributions, DataFrames, StatsModels, Random
-    using SurvivalModels: GeneralHazardModel, GHMethod, PHMethod, AFTMethod, AHMethod, simGH
+    using SurvivalModels: GeneralHazardModel, GHMethod, PHMethod, AFTMethod, AHMethod, simulate
 
     n = 100
     Random.seed!(42)
@@ -768,7 +768,7 @@ end
 
 @testitem "GeneralHazardModel fit interface for PH/AFT/AH" begin
     using SurvivalModels, Distributions, DataFrames, StatsModels, Random
-    using SurvivalModels: GeneralHazardModel, GHMethod, PHMethod, AFTMethod, AHMethod, simGH
+    using SurvivalModels: GeneralHazardModel, GHMethod, PHMethod, AFTMethod, AHMethod, simulate
 
     n = 100
     Random.seed!(42)
@@ -1143,4 +1143,38 @@ end
 
     # The direct (non-optimizing) constructor reports loglik = NaN.
     @test isnan(loglikelihood(ProportionalHazard(T, df.status, base, X1, X2, zeros(2), zeros(2))))
+end
+
+@testitem "simulate / predict from explicit baseline + design (no fitted model)" begin
+    using SurvivalModels, Distributions, Random, DataFrames
+    using SurvivalModels: PHMethod, ProportionalHazard, simulate, simGH,
+                          predict_survival, predict_expected
+
+    n = 4000
+    z = randn(MersenneTwister(1), n)
+    X = reshape(z, :, 1)
+    base = Weibull(1.3, 9.5)
+    β = [-0.5]
+
+    # pieces and formula/DataFrame forms agree (same rng), and both match the
+    # fitted-model form's delegation.
+    t_pieces = simulate(n, PHMethod(), base, X, X, [0.0], β; rng = MersenneTwister(7))
+    df = DataFrame(z = z)
+    t_formula = simulate(n, PHMethod(), base, @formula(0 ~ z), df, [0.0], β; rng = MersenneTwister(7))
+    m = ProportionalHazard(zeros(n), trues(n), base, X, X, [0.0], β)
+    t_model = simulate(n, m; rng = MersenneTwister(7))
+    @test t_formula ≈ t_pieces
+    @test t_model ≈ t_pieces
+    @test all(t_pieces .> 0)
+
+    # Deprecated simGH still delegates to simulate.
+    @test simGH(n, m; rng = MersenneTwister(7)) ≈ t_pieces
+
+    # predict pieces match the fitted-model predict, and reduce to the baseline at β = 0.
+    fitm = fit(ProportionalHazard{Weibull}, @formula(Surv(time, status) ~ z),
+               DataFrame(time = t_pieces, status = trues(n), z = z))
+    @test predict_survival(PHMethod(), fitm.baseline, X, X, [0.0], fitm.β, 5.0) ≈
+          predict(fitm, :survival, 5.0)
+    @test all(isapprox.(predict_survival(PHMethod(), base, X, X, [0.0], [0.0], 5.0), ccdf(base, 5.0)))
+    @test size(predict_expected(PHMethod(), base, X, X, [0.0], β, [1.0, 5.0, 10.0])) == (n, 3)
 end


### PR DESCRIPTION
Renames the simulation entry point to `simulate` and gives it a three-tier API that needs no fitted model, plus matching `predict_*` methods for evaluating at arbitrary parameters. Deprecates `simGH`.

### API
```julia
# simulate
simulate(n, method, baseline, X1, X2, α, β; rng)                  # pieces
simulate(n, method, baseline, formula[, formula2], df, α, β; rng) # formula + DataFrame
simulate(n, model::GeneralHazardModel; rng)                       # fitted model (delegates)

# evaluate at explicit baseline + design + coefficients (no fitted model)
predict_survival(method, baseline, X1, X2, α, β, t)               # and formula/df forms
predict_expected(method, baseline, X1, X2, α, β, t)
```

The formula/DataFrame forms build the design via `modelcols`, exactly like `fit`. All forms share the `c1`/`c2` multipliers with the fitted-model methods, so simulation and survival/cumulative-hazard stay consistent with `fit`/`predict`.

### Why
The old `simGH(n, model)` was flagged in its own docstring as a placeholder: it reused the model's stored covariates, took no `rng`, and forced you to build a dummy model (with throwaway `T`/`Δ`) just to simulate. The new pieces/formula API removes that, adds an `rng`, and makes simulating a known truth or evaluating survival at perturbed/draw parameters a one-liner.

`simGH` is kept as a deprecated alias (`Base.@deprecate`).

### Tests / docs
- New testitem: pieces == formula == model `simulate` (same `rng`); deprecated `simGH` delegates; `predict_survival`/`predict_expected` pieces match the fitted-model `predict` and reduce to the baseline at β = 0.
- Docs and existing tests migrated from `simGH` to `simulate`.
