### PR TITLE
Add aic/bic to Cox (Cox <: StatisticalModel)

### DIFF
--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -35,7 +35,7 @@ Types:
 abstract type CoxMethod end
 abstract type CoxGrad<:CoxMethod end
 abstract type CoxLLH<:CoxGrad end
-struct Cox{CM}
+struct Cox{CM} <: StatsAPI.StatisticalModel
     M::CM
     β::Vector{Float64}
     pred_names::Vector{Symbol}
@@ -51,6 +51,15 @@ function loss(beta, M::CoxMethod)
     η = getX(M) * beta
     return dot(M.Δ, log.((M.T .<= M.T') * exp.(η)) .- η)
 end
+
+# `Cox <: StatisticalModel`: the Cox *partial* log-likelihood is `-loss` (the
+# `loss` here is the negative partial log-likelihood the solvers minimize). With
+# `dof` = number of regression coefficients and `nobs` = number of subjects, the
+# generic `aic`/`aicc`/`bic` from StatsAPI work directly (no baseline params,
+# since the model is semi-parametric).
+StatsAPI.loglikelihood(C::Cox) = -loss(C.β, C.M)
+StatsAPI.dof(C::Cox) = nvar(C.M)
+StatsAPI.nobs(C::Cox) = nobs(C.M)
 
 function getβ(M::CoxGrad; max_iter = 10000, tol = 1e-9)
     β = zeros(nvar(M))

--- a/test/test.jl
+++ b/test/test.jl
@@ -1144,3 +1144,20 @@ end
     # The direct (non-optimizing) constructor reports loglik = NaN.
     @test isnan(loglikelihood(ProportionalHazard(T, df.status, base, X1, X2, zeros(2), zeros(2))))
 end
+
+@testitem "Cox fit statistics (loglikelihood/aic/bic)" begin
+    using RDatasets, DataFrames
+    using SurvivalModels: loss
+
+    ovarian = dataset("survival", "ovarian")
+    m = fit(Cox, @formula(Surv(FUTime, FUStat) ~ Age + ECOG_PS), ovarian)
+
+    # Cox partial log-likelihood is -loss; dof = #coefficients (semi-parametric,
+    # no baseline params); nobs = #subjects.
+    @test loglikelihood(m) ≈ -loss(m.β, m.M)
+    @test dof(m) == 2
+    @test nobs(m) == nrow(ovarian)
+    @test aic(m)  ≈ -2 * loglikelihood(m) + 2 * dof(m)
+    @test bic(m)  ≈ -2 * loglikelihood(m) + dof(m) * log(nobs(m))
+    @test aicc(m) ≈ aic(m) + 2 * dof(m) * (dof(m) + 1) / (nobs(m) - dof(m) - 1)
+end


### PR DESCRIPTION
Makes `Cox <: StatsAPI.StatisticalModel` and adds the primitives so the generic `aic`/`aicc`/`bic` work — useful for covariate selection by information criteria.

### Added
- `loglikelihood(::Cox)` — the Cox partial log-likelihood (`-loss`, since `loss` is the negative partial log-likelihood the solvers minimize).
- `dof(::Cox)` — number of regression coefficients (semi-parametric: no baseline parameters).
- `nobs(::Cox)` — number of subjects.

`aic`/`aicc`/`bic` then follow from the `StatisticalModel` generics.

### Tests
New testitem on the `ovarian` fixture: `loglikelihood == -loss`, `dof == 2`, `nobs == nrow`, and the AIC/AICc/BIC identities.

> Note: builds on the StatisticalModel + `nobs` work in the GeneralHazardModel fit-statistics PR (#70); easiest to review after that one (or merge #70 first and rebase).
