### PR TITLE
[NonParametric] Fix KaplanMeier formula fit on Int status (closes #77)

### DIFF
--- a/src/NonParametric/KaplanMeier.jl
+++ b/src/NonParametric/KaplanMeier.jl
@@ -93,11 +93,13 @@ struct KaplanMeier{T}
 end
 
 function StatsBase.fit(::Type{T}, formula::FormulaTerm, df::DataFrame) where {T<:KaplanMeier}
-    lhs_vars = StatsModels.termvars(formula.lhs)
-    resp = modelcols(formula.lhs, df[:, lhs_vars])
-    Tvec = getindex.(resp, 1)
-    Δvec = getindex.(resp, 2)
-    return KaplanMeier(Tvec, Δvec)
+    # `schema(formula, df)` reads only the columns the formula references, then
+    # `apply_schema` turns the `Surv(t, s)` LHS into a response term whose
+    # `modelcols` returns an `n×2` matrix: column 1 the times, column 2 the event
+    # indicator. Coerce the indicator to `Bool` for the constructor.
+    formula_applied = apply_schema(formula, schema(formula, df))
+    resp = modelcols(formula_applied.lhs, df)
+    return KaplanMeier(resp[:, 1], Bool.(resp[:, 2]))
 end
 
 # Survival estimate Ŝ(t)

--- a/test/test.jl
+++ b/test/test.jl
@@ -769,6 +769,34 @@ end
     @test isapprox(lrt1.pval, lrt2.pval; atol=1e-8)
 end
 
+@testitem "KaplanMeier fit() accepts Int/Float status columns (issue #77)" begin
+    using SurvivalModels: KaplanMeier
+    using DataFrames, StatsModels
+
+    T = Float64[2, 3, 4, 5, 8, 3, 6]
+    D = [1, 1, 0, 1, 0, 1, 1]              # natural Int 0/1 encoding
+    ref = KaplanMeier(T, D)
+
+    # The formula fit accepts the status column in any of the encodings a user
+    # might supply, and produces the same estimator as the direct constructor.
+    for status in (D, Bool.(D), Float64.(D))
+        df = DataFrame(time = T, status = status)
+        km = fit(KaplanMeier, @formula(Surv(time, status) ~ 1), df)
+        @test km.t  == ref.t
+        @test km.∂N == ref.∂N
+        @test km.Y  == ref.Y
+        @test km.∂Λ == ref.∂Λ
+    end
+
+    # Columns not referenced by the formula are ignored, even a single-level
+    # categorical that would otherwise fail contrast construction (as arises when
+    # a frame is subset to one group before fitting an intercept-only KM).
+    df = DataFrame(time = T, status = D, grp = fill("Obs", length(T)))
+    km = fit(KaplanMeier, @formula(Surv(time, status) ~ 1), df)
+    @test km.t == ref.t
+    @test km.∂Λ == ref.∂Λ
+end
+
 @testitem "GeneralHazardModel direct construction and simulation" begin
     using SurvivalModels, Distributions, Random
     using SurvivalModels: GeneralHazardModel, GHMethod, PHMethod, AFTMethod, AHMethod, simulate


### PR DESCRIPTION
## Summary

Fixes the documented `fit(KaplanMeier, @formula(Surv(t, s) ~ 1), df)` interface, which errored when the status column was `Int` (the natural `0/1` encoding):

```
ERROR: MethodError: no method matching Surv(::Float64, ::Int64)
```

`KaplanMeier`'s fit built the response with `modelcols` on the raw formula LHS. Without `apply_schema`, `Surv(t, s)` is a plain `FunctionTerm`, so `modelcols` applies `Surv` element-wise across rows (`Surv.(t, s)`); `SurvivalBase.Surv` only accepts a `Bool` event indicator, so an `Int` status column raised the `MethodError`. `Cox`'s fit was unaffected because it resolves the response through the schema.

## Change

Resolve the response through the schema and read the times and event indicator from the resulting `n×2` response matrix (coercing the indicator to `Bool`). This also removes the fragile `getindex.(resp, 1/2)` element-wise extraction.

The schema is scoped to the formula's variables via `schema(formula, df)` (rather than `schema(df)` over the whole frame). `schema(df)` eagerly builds contrasts for every column, so a column the formula does not reference — e.g. a single-level categorical left over after subsetting a frame to one group — fails contrast construction (`ArgumentError: only one level found`). Scoping to `termvars(formula)` leaves such columns untouched. This surfaced as a failure of the colon case-study docs example, which fits an intercept-only KM on data subset to one `Rx` level.

## Tests

- Regression testitem fitting the formula interface with `Int`, `Bool`, and `Float64` status columns, each checked against the direct `KaplanMeier(T, Δ)` constructor. The pre-existing fit test only exercised `Bool` status, which is why the original bug slipped through.
- A case with an unrelated single-level categorical column in the frame, covering the schema-scoping fix.

Docs build verified locally (`docs/make.jl`) — the previously failing `case_study.md` `@example` blocks now run.

Closes #77.
