### PR TITLE
[NonParametric] Fix KaplanMeier confint: level is the confidence level

### DIFF
--- a/docs/src/nonparametric/kaplanmeier.md
+++ b/docs/src/nonparametric/kaplanmeier.md
@@ -105,6 +105,7 @@ predict(km, :survival, [1.0, 5.0, 8.0])  # Ŝ at the given times
 KaplanMeier
 predict(::KaplanMeier)
 greenwood
+confint(::KaplanMeier)
 ```
 
 ```@bibliography

--- a/src/NonParametric/KaplanMeier.jl
+++ b/src/NonParametric/KaplanMeier.jl
@@ -160,7 +160,15 @@ The Greenwood formula provides an estimate of the variance of the Kaplan-Meier s
 """
 greenwood(S::KaplanMeier, t) = sum(S.∂σ[i] for i in eachindex(S.t) if S.t[i] < t)
 
-function StatsAPI.confint(S::KaplanMeier; level::Real=0.05)
+"""
+    confint(km::KaplanMeier; level::Real=0.95)
+
+Pointwise confidence intervals for the Kaplan-Meier survival function, using the
+log-log transform and Greenwood's variance estimate. `level` is the confidence
+level (e.g. `0.95` for 95% intervals). Returns a `DataFrame` with columns `time`,
+`surv`, `lower`, and `upper`.
+"""
+function StatsAPI.confint(S::KaplanMeier; level::Real=0.95)
     n = length(S.t)
     surv = ones(Float64, n)
     for i in 1:n
@@ -173,8 +181,8 @@ function StatsAPI.confint(S::KaplanMeier; level::Real=0.05)
         acc += S.∂σ[i]
         var[i] = (surv[i]^2) * acc
     end
-    # z-value for confidence level
-    z = quantile(Normal(), 1 - level/2)
+    # z-value for the two-sided interval at the given confidence level
+    z = quantile(Normal(), (1 + level) / 2)
     lower = similar(surv)
     upper = similar(surv)
     for i in 1:n

--- a/test/test.jl
+++ b/test/test.jl
@@ -1182,6 +1182,32 @@ end
     @test S[3] ≈ 0.496732026143791 atol = 1e-12
 end
 
+@testitem "KaplanMeier confint level is the confidence level" begin
+    using DataFrames, Distributions
+    using SurvivalModels: KaplanMeier
+
+    T = Float64[2, 3, 4, 5, 8, 3, 6, 9, 11, 7]
+    Δ = Bool[1, 1, 0, 1, 0, 1, 1, 0, 1, 1]
+    km = KaplanMeier(T, Δ)
+
+    ci95 = confint(km)                 # default must be 95%
+    ci95e = confint(km, level = 0.95)
+    ci99 = confint(km, level = 0.99)
+
+    # `level` is the confidence level (StatsAPI convention), so the default is 95%.
+    @test ci95.lower == ci95e.lower
+    @test ci95.upper == ci95e.upper
+
+    # Higher confidence ⇒ wider interval. Under the old `level`-as-alpha bug,
+    # level = 0.99 produced z = quantile(Normal(), 1 - 0.99/2) ≈ 0.0125 and hence
+    # far *narrower* intervals, so this ordering is the regression guard.
+    for i in eachindex(km.t)
+        0 < ci95.surv[i] < 1 || continue
+        @test ci99.lower[i] ≤ ci95.lower[i]
+        @test ci99.upper[i] ≥ ci95.upper[i]
+    end
+end
+
 @testitem "GeneralHazardModel fit statistics (loglikelihood/aic/bic/coef/vcov)" begin
     using DataFrames, Distributions, LinearAlgebra
     using SurvivalModels: ProportionalHazard, AcceleratedFaillureTime,


### PR DESCRIPTION
## Summary

`confint(::KaplanMeier)` treated `level` as the significance level α rather than the confidence level. With the default `level = 0.05` it computed

```julia
z = quantile(Normal(), 1 - level/2)   # = quantile(Normal(), 0.975) = 1.96
```

so it returned a **95%** band from a parameter that reads as `0.95`, and, worse, a non-default call went the wrong way: `confint(km, level = 0.99)` produced `z = quantile(Normal(), 1 - 0.99/2) ≈ 0.0125`, i.e. an essentially **1%** band. StatsAPI's convention is that `level` is the *confidence* level (`confint(m; level = 0.95)`).

## Change

- Default to `level = 0.95` and compute `z = quantile(Normal(), (1 + level)/2)` (equivalently `1 - (1 - level)/2`), so `0.95 → 1.96` and `0.99 → 2.576`.
- Add a docstring documenting that `level` is the confidence level, and list it on the Kaplan-Meier docs page.

The default output is numerically unchanged (both old and new defaults give a 95% band), so existing 95% results and the docs example are unaffected; only explicitly-specified non-95% levels change — and now correctly.

## Tests

Regression testitem asserting that the default equals `level = 0.95` and that a higher confidence level widens the interval (the ordering the old α-based code inverted).

Docs build verified locally.
