### PR TITLE
Add show/coeftable/confint to models; KaplanMeier show (closes #78, #79)

### DIFF
--- a/docs/src/parametric/example.md
+++ b/docs/src/parametric/example.md
@@ -4,6 +4,8 @@ In this example, we simulate ``n=100`` times to event from the GH, PH, AFT, and 
 
 ## PGW-GH model
 
+The fitted model displays the baseline distribution and the two coefficient sets grouped by role (`time-scale` for `X_2`, `hazard-level` for `X_1`):
+
 ```@example 1
 using SurvivalModels, Distributions, DataFrames, Random, SurvivalDistributions
 using SurvivalModels: simulate
@@ -38,7 +40,11 @@ model = fit(GeneralHazard{PowerGeneralizedWeibull},
     @formula(Surv(time, status) ~ x1 + x2), 
     @formula(Surv(time, status) ~ z1 + z2), 
     df)
+```
 
+Comparing the fitted values against the truth:
+
+```@example 1
 result = DataFrame(
     Parameter = ["θ₁", "θ₂", "θ₃", "α₁", "α₂","β₁", "β₂"],
     True      = vcat(theta0, alpha0, beta0),
@@ -68,7 +74,9 @@ simdat = min.(simdat, cens)
 df = DataFrame(time=simdat, status=status, x1=des[:,1], x2=des[:,2])
 model = fit(ProportionalHazard{PowerGeneralizedWeibull}, 
     @formula(Surv(time, status) ~ x1 + x2), df)
+```
 
+```@example 1
 result = DataFrame(
     Parameter = ["θ₁", "θ₂", "θ₃", "β₁", "β₂"],
     True      = vcat(theta0, beta0),
@@ -98,7 +106,9 @@ simdat = min.(simdat, cens)
 df = DataFrame(time=simdat, status=status, x1=des[:,1], x2=des[:,2])
 model = fit(AcceleratedFaillureTime{PowerGeneralizedWeibull}, 
     @formula(Surv(time, status) ~ x1 + x2), df)
+```
 
+```@example 1
 result = DataFrame(
     Parameter = ["θ₁", "θ₂", "θ₃", "β₁", "β₂"],
     True      = vcat(theta0, beta0),
@@ -125,7 +135,9 @@ simdat = min.(simdat, cens)
 df = DataFrame(time=simdat, status=status, z1=des_t[:,1], z2=des_t[:,2])
 model = fit(AcceleratedHazard{PowerGeneralizedWeibull}, 
     @formula(Surv(time, status) ~ z1 + z2), df)
+```
 
+```@example 1
 result = DataFrame(
     Parameter = ["θ₁", "θ₂", "θ₃", "α₁", "α₂"],
     True      = vcat(theta0, alpha0),

--- a/docs/src/parametric/fitting.md
+++ b/docs/src/parametric/fitting.md
@@ -8,12 +8,16 @@ A model is fitted from data with `fit(Model, @formula(Surv(time, status) ~ ...),
 
 `GeneralHazardModel <: StatsAPI.StatisticalModel`, so a fitted model supports the standard statistical-model accessors. `aic`, `aicc`, and `bic` follow from `loglikelihood`, `dof`, and `nobs`; `stderror` follows from `vcov`. `coef` and `vcov` are reported on the inference scale `[log.(baseline parameters); active regression coefficients]`, so `MvNormal(coef(m), vcov(m))` is a coherent parameter-uncertainty distribution.
 
+For a fitted-model report, `coeftable(m)` gives the Wald table of covariate effects (with `exp(coef)` and its confidence interval) and `confint(m)` the coefficient intervals as a `DataFrame`; both exclude the baseline distribution parameters, which `show` reports as the fitted baseline instead.
+
 ```@docs
 SurvivalModels.loglikelihood(::SurvivalModels.GeneralHazardModel)
 SurvivalModels.nobs(::SurvivalModels.GeneralHazardModel)
 SurvivalModels.dof(::SurvivalModels.GeneralHazardModel)
 SurvivalModels.coef(::SurvivalModels.GeneralHazardModel)
 SurvivalModels.vcov(::SurvivalModels.GeneralHazardModel)
+SurvivalModels.coeftable(::SurvivalModels.GeneralHazardModel)
+SurvivalModels.confint(::SurvivalModels.GeneralHazardModel)
 ```
 
 ### Brier score

--- a/docs/src/semiparametric/cox.md
+++ b/docs/src/semiparametric/cox.md
@@ -223,21 +223,22 @@ colon = dataset("survival", "colon")
 colon.Time = Float64.(colon.Time)
 colon.Status = Bool.(colon.Status)
 model_colon = fit(Cox, @formula(Surv(Time, Status) ~ Age + Rx), colon)
-
+coeftable(model_colon)
 ```
 
-The outputed dataframe contains columns with respectively the name of the predictor, the obtained coefficients, its standard error, the associated p-value and the test statistic z as just described. 
+The table has one row per coefficient with the estimate (log hazard ratio), its standard error, the Wald `z` statistic and p-value, the hazard ratio `exp(coef)`, and the confidence interval for the hazard ratio.
 
 ```@docs
 CoxMethod
 ```
 
-### Model Summary & Extraction
+### Coefficient Table & Extraction
 
-To inspect the model statistics programmatically (such as extracting standard errors, p-values, or confidence intervals), you can use the `summary` function. This returns a DataFrame allowing for easy data manipulation.
+`coeftable(model)` returns the inference table above; `confint(model)` returns the coefficient confidence intervals as a `DataFrame` for programmatic use. Both take a `level` keyword (default `0.95`).
 
 ```@docs
-summary(::SurvivalModels.Cox)
+coeftable(::SurvivalModels.Cox)
+confint(::SurvivalModels.Cox)
 ```
 
 
@@ -645,14 +646,13 @@ The C-index measures the proportion of all usable patient pairs in which the pre
 SurvivalModels.harrells_c
 ```
 
-The C-index ranges from 0.5 (no better than random) to 1.0 (perfect discrimination). It is outputed by the show function, and can be queried seprately too: 
+The C-index ranges from 0.5 (no better than random) to 1.0 (perfect discrimination).
 
-You can compute the C-index for a fitted Cox model using:
+You can compute the C-index for a fitted Cox model with `harrells_c`:
 
 ```@example 2
 model = fit(Cox, @formula(Surv(Time, Status) ~ Age + Rx), colon)
 cindex = SurvivalModels.harrells_c(model)
-model
 ```
 
 A higher C-index indicates better predictive discrimination.

--- a/src/NonParametric/KaplanMeier.jl
+++ b/src/NonParametric/KaplanMeier.jl
@@ -93,6 +93,13 @@ struct KaplanMeier{T}
 end
 
 function StatsBase.fit(::Type{T}, formula::FormulaTerm, df::DataFrame) where {T<:KaplanMeier}
+    # `KaplanMeier` estimates a single survival curve; right-hand-side variables
+    # would silently be ignored (it is not a stratified estimator), so reject them
+    # rather than return a misleading pooled curve. See issue on stratification.
+    isempty(StatsModels.termvars(formula.rhs)) || throw(ArgumentError(
+        "KaplanMeier estimates a single survival curve and does not support " *
+        "right-hand-side variables; use `Surv(t, s) ~ 1`. Fit separate curves per " *
+        "group, or use `LogRankTest` to compare groups."))
     # `schema(formula, df)` reads only the columns the formula references, then
     # `apply_schema` turns the `Surv(t, s)` LHS into a response term whose
     # `modelcols` returns an `n×2` matrix: column 1 the times, column 2 the event
@@ -202,3 +209,23 @@ function StatsAPI.confint(S::KaplanMeier; level::Real=0.95)
     end
     return DataFrame(time=S.t, surv=surv, lower=lower, upper=upper)
 end
+
+# Median survival: the smallest event/censor time at which Ŝ drops to or below
+# 0.5, or `NaN` if the curve never reaches 0.5.
+function _km_median(km::KaplanMeier)
+    surv = cumprod(1 .- km.∂Λ)
+    idx = findfirst(<=(0.5), surv)
+    return idx === nothing ? NaN : km.t[idx]
+end
+
+# Total sample size = number at risk just before the first event/censor time.
+_km_nobs(km::KaplanMeier) = isempty(km.Y) ? 0 : km.Y[1]
+
+function Base.show(io::IO, ::MIME"text/plain", km::KaplanMeier)
+    med = _km_median(km)
+    println(io, "Kaplan-Meier survival estimate")
+    println(io, "  n: ", _km_nobs(km), ", events: ", sum(km.∂N))
+    println(io, "  median survival: ", isnan(med) ? "NA" : _coef_fmt(med))
+end
+
+Base.show(io::IO, km::KaplanMeier) = print(io, "KaplanMeier(n=", _km_nobs(km), ")")

--- a/src/Parametric/GeneralHazard.jl
+++ b/src/Parametric/GeneralHazard.jl
@@ -286,6 +286,162 @@ function StatsAPI.vcov(m::GeneralHazardModel{Method,B}) where {Method,B}
     return inv(H[idx, idx])
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Coefficient names, inference tables, and display
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Human-readable model name for a fitting method.
+_gh_model_name(::PHMethod)  = "Proportional hazard"
+_gh_model_name(::AFTMethod) = "Accelerated failure time"
+_gh_model_name(::AHMethod)  = "Accelerated hazard"
+_gh_model_name(::GHMethod)  = "General hazard"
+
+# Names for the `log`-scale baseline parameters that lead `coef`. Field names are
+# used only when they match the parameter count (they do for e.g. Weibull/Gamma
+# but not for the SurvivalDistributions LogLogistic/GeneralizedGamma wrappers),
+# otherwise fall back to generic `θᵢ`.
+function _gh_baseline_names(d)
+    npd = length(Distributions.params(d))
+    fn = fieldnames(typeof(d))
+    base = length(fn) == npd ? string.(collect(fn)) : ["θ$i" for i in 1:npd]
+    return ["log($n)" for n in base]
+end
+
+# Regression-coefficient names from the stored formulas (X1 ↔ β, X2 ↔ α), falling
+# back to generic names when no formula was captured or the count doesn't match.
+_gh_rhs_names(::Nothing, k, pre) = ["$pre$i" for i in 1:k]
+function _gh_rhs_names(f::FormulaTerm, k, pre)
+    nm = try
+        string.(coefnames(f.rhs))
+    catch
+        String[]
+    end
+    return length(nm) == k ? nm : ["$pre$i" for i in 1:k]
+end
+
+# The active covariate blocks, in `coef` order, each tagged with its role: a
+# covariate acts either on the hazard multiplier (`c₂`, "hazard-level") or on the
+# time scale (`c₁`, "time-scale"). Which block is active — and its role — is
+# method-specific. `:β` is the X1 block, `:α` the X2 block.
+_gh_blocks(::PHMethod)  = (("hazard-level", :β),)
+_gh_blocks(::AFTMethod) = (("time-scale", :β),)
+_gh_blocks(::AHMethod)  = (("time-scale", :α),)
+_gh_blocks(::GHMethod)  = (("time-scale", :α), ("hazard-level", :β))
+
+# Term names and estimates for one block.
+_gh_block_terms(m::GeneralHazardModel, which::Symbol) =
+    which === :β ? (_gh_rhs_names(m.formula1, length(m.β), "β"), m.β) :
+                   (_gh_rhs_names(m.formula2, length(m.α), "α"), m.α)
+
+# Active covariate names, qualified with the role when more than one block is
+# active (only the GH model), so a covariate appearing in both blocks stays
+# distinguishable. Aligned with the regression part of `coef`.
+function _gh_regression_names(m::GeneralHazardModel{M}) where {M}
+    blocks = _gh_blocks(M())
+    qualify = length(blocks) > 1
+    names = String[]
+    for (role, which) in blocks
+        nm, _ = _gh_block_terms(m, which)
+        append!(names, qualify ? ["$n [$role]" for n in nm] : nm)
+    end
+    return names
+end
+
+"""
+    coefnames(m::GeneralHazardModel)
+
+Names aligned with [`coef`](@ref): the `log`-scale baseline parameters followed by
+the active regression coefficients.
+"""
+StatsAPI.coefnames(m::GeneralHazardModel) =
+    vcat(_gh_baseline_names(m.baseline), _gh_regression_names(m))
+
+
+# Estimates and standard errors for the active covariate coefficients, grouped by
+# role in `coef` order. `stderror` covers `[baseline; regression]`, so the leading
+# `npd` baseline entries are dropped. Baseline parameters are intentionally
+# excluded from the coefficient table: a Wald test against 0 is the question for a
+# covariate effect but not for a baseline shape/scale, which `show` reports as the
+# fitted distribution instead.
+function _gh_covariate_estimates(m::GeneralHazardModel{M}) where {M}
+    npd = length(Distributions.params(m.baseline))
+    se_reg = stderror(m)[(npd + 1):end]
+    roles, terms, est, se = String[], String[], Float64[], Float64[]
+    off = 0
+    for (role, which) in _gh_blocks(M())
+        nm, v = _gh_block_terms(m, which)
+        k = length(nm)
+        append!(roles, fill(role, k))
+        append!(terms, nm)
+        append!(est, v)
+        append!(se, se_reg[off .+ (1:k)])
+        off += k
+    end
+    return roles, terms, est, se
+end
+
+"""
+    confint(m::GeneralHazardModel; level::Real=0.95)
+
+Wald confidence intervals for the covariate coefficients at confidence level
+`level`. Returns a `DataFrame` with columns `component` (the coefficient's role,
+`"hazard-level"` or `"time-scale"`), `term`, `lower`, and `upper`. Baseline
+distribution parameters are not included (see [`coeftable`](@ref)).
+"""
+function StatsAPI.confint(m::GeneralHazardModel; level::Real = 0.95)
+    roles, terms, b, se = _gh_covariate_estimates(m)
+    z = quantile(Normal(), (1 + level) / 2)
+    return DataFrame(component = roles, term = terms, lower = b .- z .* se, upper = b .+ z .* se)
+end
+
+"""
+    coeftable(m::GeneralHazardModel; level::Real=0.95)
+
+Wald coefficient table for the covariate effects: estimate, standard error, `z`,
+p-value, `exp(coef)`, and the confidence interval for `exp(coef)` at level
+`level`. `exp(coef)` is a hazard ratio for `hazard-level` effects and a
+time/acceleration ratio for `time-scale` effects. For a General Hazard model the
+rows are tagged with their role (`hazard-level` vs `time-scale`), since a
+covariate may enter both. Baseline distribution parameters are reported by `show`,
+not here: a null of zero is not the relevant hypothesis for a baseline
+shape/scale.
+"""
+function StatsAPI.coeftable(m::GeneralHazardModel; level::Real = 0.95)
+    roles, terms, b, se = _gh_covariate_estimates(m)
+    rownms = length(unique(roles)) > 1 ? ["$t [$r]" for (t, r) in zip(terms, roles)] : terms
+    return _hr_coeftable(b, se, rownms; level = level)
+end
+
+# Terse, faithful-to-the-object display: fitted baseline and regression
+# coefficients plus fit statistics — no covariance-derived quantities. Inference
+# (standard errors, tests, intervals) is deferred to `coeftable`/`confint`, which
+# take the confidence level that has no place in a zero-argument display.
+function Base.show(io::IO, ::MIME"text/plain", m::GeneralHazardModel{M,B}) where {M,B}
+    println(io, _gh_model_name(M()), " model (", nameof(B), " baseline)")
+    println(io, "  n: ", nobs(m), ", events: ", Int(sum(m.Δ)))
+    if !isnan(m.loglik)
+        println(io, "  log-likelihood: ", _coef_fmt(loglikelihood(m)),
+            ", AIC: ", _coef_fmt(aic(m)), ", BIC: ", _coef_fmt(bic(m)))
+    end
+    bp = _coef_fmt.(collect(Float64, Distributions.params(m.baseline)))
+    println(io, "  baseline: ", nameof(B), "(", join(bp, ", "), ")")
+    blocks = _gh_blocks(M())
+    grouped = length(blocks) > 1
+    println(io, "  coefficients:")
+    for (role, which) in blocks
+        nm, v = _gh_block_terms(m, which)
+        grouped && println(io, "    ", role, ":")
+        indent = grouped ? "      " : "    "
+        w = isempty(nm) ? 0 : maximum(length, nm)
+        for (n, x) in zip(nm, v)
+            println(io, indent, rpad(n, w), "  ", _coef_fmt(x))
+        end
+    end
+end
+
+Base.show(io::IO, m::GeneralHazardModel{M,B}) where {M,B} =
+    print(io, _gh_model_name(M()), "{", nameof(B), "}(n=", nobs(m), ")")
+
 """
     _initial_baseline_log_params(baseline, T) -> Vector{Float64}
 

--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -60,6 +60,10 @@ end
 StatsAPI.loglikelihood(C::Cox) = -loss(C.β, C.M)
 StatsAPI.dof(C::Cox) = nvar(C.M)
 StatsAPI.nobs(C::Cox) = nobs(C.M)
+StatsAPI.coef(C::Cox) = C.β
+StatsAPI.coefnames(C::Cox) = string.(C.pred_names)
+# Observed information from the fit; `stderror`/`coeftable`/`confint` derive from it.
+StatsAPI.vcov(C::Cox) = inv(get_hessian(C))
 
 function getβ(M::CoxGrad; max_iter = 10000, tol = 1e-9)
     β = zeros(nvar(M))
@@ -409,61 +413,46 @@ function StatsBase.fit(::Type{T}, formula::FormulaTerm, df::DataFrame) where T<:
 end
 
 """
-    summary(model::Cox)
+    coeftable(model::Cox; level::Real=0.95)
 
-Compute a statistical summary table for a fitted Cox proportional hazards model.
-
-This function calculates standard errors, z-scores, p-values, and confidence intervals.
-
-# Returns
-A `DataFrame` with the following columns:
-- `predictor`: Name of the covariate.
-- `β`: Estimated regression coefficient.
-- `e_β`: Hazard ratio (exp(β)).
-- `se`: Standard error of the coefficient.
-- `z_scores`: Wald statistic (β / se).
-- `p_values`: Two-sided p-value.
-- `ci_lower_β`: Lower bound of the 95% confidence interval for β.
-- `ci_upper_β`: Upper bound of the 95% confidence interval for β.
-
-# Example
-```julia
-model = fit(Cox, @formula(Surv(time, status) ~ age + sex), df)
-
-# Get the full summary dataframe
-summ = summary(model)
-
-# Extract standard errors specifically
-standard_errors = summ.se
-```
+Wald coefficient table for a fitted Cox model: the coefficient (log hazard
+ratio), its standard error, the `z` statistic, the two-sided p-value, the hazard
+ratio `exp(coef)`, and the confidence interval for the hazard ratio at confidence
+level `level` (matching R's `summary(coxph)` convention).
 """
-function summary(C::Cox)
-    # Standard Error, z-score, p-values and c-index: 
-    se = sqrt.(diag(inv(get_hessian(C.M, C.β))))
-    z_scores = C.β ./ se
-    p_values = 2 .* ccdf.(Normal(), abs.(z_scores))
+StatsAPI.coeftable(C::Cox; level::Real = 0.95) =
+    _hr_coeftable(coef(C), stderror(C), coefnames(C); level = level)
 
-    q = quantile(Normal(), 0.975) 
-    ci_lower_β = C.β .- se .* q
-    ci_upper_β = C.β .+ se .* q
-    return DataFrame(
-        predictor = C.pred_names,
-        β = C.β,
-        e_β = exp.(C.β),
-        se = se,
-        z_scores = z_scores,
-        p_values = p_values,
-        ci_lower_β  = ci_lower_β,
-        ci_upper_β = ci_upper_β
-    )
+"""
+    confint(model::Cox; level::Real=0.95)
+
+Wald confidence intervals for the coefficients (log-hazard-ratio scale) at
+confidence level `level`. Returns a `DataFrame` with columns `term`, `lower`,
+`upper`.
+"""
+function StatsAPI.confint(C::Cox; level::Real = 0.95)
+    b = coef(C)
+    se = stderror(C)
+    z = quantile(Normal(), (1 + level) / 2)
+    return DataFrame(term = coefnames(C), lower = b .- z .* se, upper = b .+ z .* se)
 end
 
-function _summary_line(C::Cox)
-    c_index = harrells_c(C)
-    return "Cox Model (n: $(nobs(C.M)), m: $(nvar(C.M)), method: $(typeof(C).parameters[1]), C-index: $(c_index))"
-end
+# One-line descriptor. Deliberately cheap: no C-index (it is O(n²)) and no
+# covariance-derived quantities — `show` stays faithful to the fitted object, and
+# inference lives in `coeftable`/`confint`.
+_summary_line(C::Cox) = "Cox model (method: $(nameof(typeof(C).parameters[1])))"
 
-function Base.show(io::IO, C::Cox)
+function Base.show(io::IO, ::MIME"text/plain", C::Cox)
     println(io, _summary_line(C))
-    Base.show(summary(C))
+    println(io, "  n: ", nobs(C), ", events: ", Int(sum(C.M.Δ)))
+    println(io, "  log-likelihood: ", _coef_fmt(loglikelihood(C)),
+        ", AIC: ", _coef_fmt(aic(C)), ", BIC: ", _coef_fmt(bic(C)))
+    println(io, "  coefficients:")
+    nm, b = coefnames(C), coef(C)
+    w = isempty(nm) ? 0 : maximum(length, nm)
+    for (n, x) in zip(nm, b)
+        println(io, "    ", rpad(n, w), "  ", _coef_fmt(x))
+    end
 end
+
+Base.show(io::IO, C::Cox) = print(io, _summary_line(C))

--- a/src/SurvivalModels.jl
+++ b/src/SurvivalModels.jl
@@ -13,6 +13,6 @@ include("Semiparametric/Cox.jl")
 include("Parametric/GeneralHazard.jl")
 include("Metrics/BrierScore.jl")
 
-export fit, predict, KaplanMeier, LogRankTest, Cox, @formula, Surv, Strata, confint, GeneralHazard, ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, PHMethod, AFTMethod, AHMethod, GHMethod, simulate, simGH, predict_survival, predict_expected, loss, loglikelihood, aic, aicc, bic, dof, nobs, coef, vcov, stderror
+export fit, predict, KaplanMeier, LogRankTest, Cox, @formula, Surv, Strata, confint, GeneralHazard, ProportionalHazard, AcceleratedFaillureTime, AcceleratedHazard, PHMethod, AFTMethod, AHMethod, GHMethod, simulate, simGH, predict_survival, predict_expected, loss, loglikelihood, aic, aicc, bic, dof, nobs, coef, vcov, stderror, coeftable
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,27 @@
 
+# Rounded formatting for coefficient/parameter values in `show` methods.
+_coef_fmt(x) = string(round(x; sigdigits = 5))
+
+# Confidence level as a compact percentage string, e.g. 0.95 -> "95", 0.9 -> "90".
+_ci_levstr(level) = (v = 100 * level; isinteger(v) ? string(Int(v)) : string(v))
+
+# Wald coefficient table shared by the hazard-based regression models: estimate,
+# standard error, `z`, p-value, `exp(coef)`, and the confidence interval for
+# `exp(coef)` at `level`. `exp(coef)` is a hazard ratio for hazard-level effects
+# and a time/acceleration ratio for time-scale effects; the row names carry that
+# distinction.
+function _hr_coeftable(b, se, rownms; level::Real = 0.95)
+    z = b ./ se
+    p = 2 .* ccdf.(Normal(), abs.(z))
+    zc = quantile(Normal(), (1 + level) / 2)
+    ls = _ci_levstr(level)
+    return CoefTable(
+        [b, se, z, p, exp.(b), exp.(b .- zc .* se), exp.(b .+ zc .* se)],
+        ["Coef.", "Std. Error", "z", "Pr(>|z|)", "exp(coef)", "Lower $ls%", "Upper $ls%"],
+        rownms, 4, 3,
+    )
+end
+
 """
     harrells_c(times, statuses, risk_scores)
     harrels_c(C::Cox)

--- a/test/test.jl
+++ b/test/test.jl
@@ -1338,3 +1338,101 @@ end
         @test g_analytic ≈ g_ad rtol=1e-8
     end
 end
+
+@testitem "Cox show / coeftable / confint reference output" begin
+    using SurvivalModels, StatsBase, DataFrames, StableRNGs, Distributions
+    using SurvivalModels: PHMethod, simulate
+
+    rng = StableRNG(11); n = 200
+    x = randn(rng, n); g = Float64.(rand(rng, n) .< 0.5)
+    Ts = simulate(n, PHMethod(), Weibull(1.5, 2.0), hcat(x, g), zeros(n, 0), Float64[], [0.6, -0.4]; rng)
+    df = DataFrame(time = min.(Ts, 4.0), status = Ts .<= 4.0, x = x, g = g)
+    m = fit(Cox, @formula(Surv(time, status) ~ x + g), df)
+
+    # `show` renders stored state only (no covariance-derived quantities).
+    @test repr(MIME"text/plain"(), m) ==
+        "Cox model (method: CoxDefault)\n  n: 200, events: 178\n  log-likelihood: -795.36, AIC: 1594.7, BIC: 1601.3\n  coefficients:\n    x  0.4765\n    g  -0.17793\n"
+
+    ct = coeftable(m)
+    @test ct.colnms == ["Coef.", "Std. Error", "z", "Pr(>|z|)", "exp(coef)", "Lower 95%", "Upper 95%"]
+    @test ct.rownms == ["x", "g"]
+    @test ct.cols[5] ≈ exp.(coef(m))                       # exp(coef) column
+    ci = confint(m)
+    @test names(ci) == ["term", "lower", "upper"]
+    @test ci.term == ["x", "g"]
+    @test ct.cols[6] ≈ exp.(ci.lower)                      # coeftable CI is exp of the coef-scale confint
+    @test ct.cols[7] ≈ exp.(ci.upper)
+    @test ci.lower ≈ coef(m) .- quantile(Normal(), 0.975) .* stderror(m)
+end
+
+@testitem "GeneralHazardModel show grouping (issue #78)" begin
+    using SurvivalModels, StatsBase, Distributions
+
+    T = [1.0, 2, 3, 4, 5]; D = Bool[1, 0, 1, 1, 0]; X = reshape([0.5, -0.5, 1.0, -1.0, 0.0], :, 1)
+
+    # Direct construction performs no optimization, so the display is fully
+    # deterministic (loglik = NaN, so that line is omitted).
+    mph = ProportionalHazard(T, D, Weibull(1.2, 2.0), X, X, [0.0], [0.7])
+    @test repr(MIME"text/plain"(), mph) ==
+        "Proportional hazard model (Weibull baseline)\n  n: 5, events: 3\n  baseline: Weibull(1.2, 2.0)\n  coefficients:\n    β1  0.7\n"
+
+    # A General Hazard model has two coefficient sets, shown under role sub-headers.
+    mgh = GeneralHazard(T, D, Weibull(1.2, 2.0), X, X, [0.3], [0.7])
+    @test repr(MIME"text/plain"(), mgh) ==
+        "General hazard model (Weibull baseline)\n  n: 5, events: 3\n  baseline: Weibull(1.2, 2.0)\n  coefficients:\n    time-scale:\n      α1  0.3\n    hazard-level:\n      β1  0.7\n"
+end
+
+@testitem "GeneralHazardModel coeftable / confint" begin
+    using SurvivalModels, StatsBase, DataFrames, StableRNGs, Distributions
+    using SurvivalModels: PHMethod, GHMethod, simulate
+
+    rng = StableRNG(7); n = 300
+    z = randn(rng, n); w = randn(rng, n)
+
+    # PH: single hazard-level block. coeftable excludes baseline params (bare names).
+    Tph = simulate(n, PHMethod(), Weibull(1.5, 2.0), hcat(z, w), zeros(n, 0), Float64[], [0.7, -0.3]; rng)
+    dph = DataFrame(time = min.(Tph, 4.0), status = Tph .<= 4.0, z = z, w = w)
+    mph = fit(ProportionalHazard{Weibull}, @formula(Surv(time, status) ~ z + w), dph)
+    ctp = coeftable(mph)
+    @test ctp.colnms == ["Coef.", "Std. Error", "z", "Pr(>|z|)", "exp(coef)", "Lower 95%", "Upper 95%"]
+    @test ctp.rownms == ["z", "w"]              # covariates only, no baseline rows, no role qualifier
+    @test ctp.cols[5] ≈ exp.(ctp.cols[1])       # exp(coef)
+    cip = confint(mph)
+    @test names(cip) == ["component", "term", "lower", "upper"]
+    @test all(==("hazard-level"), cip.component)
+    @test cip.term == ["z", "w"]
+    sp = repr(MIME"text/plain"(), mph)
+    @test occursin("log-likelihood:", sp)
+    @test !occursin("hazard-level:", sp)        # single set ⇒ no role sub-header
+
+    # GH: two blocks on distinct covariates (X1↔β↔z, X2↔α↔w) ⇒ well-identified;
+    # rows are role-qualified, time-scale (α) block before hazard-level (β).
+    Tgh = simulate(n, GHMethod(), Weibull(1.5, 2.0), reshape(z, :, 1), reshape(w, :, 1), [0.4], [0.6]; rng)
+    dgh = DataFrame(time = min.(Tgh, 4.0), status = Tgh .<= 4.0, z = z, w = w)
+    mgh = fit(GeneralHazard{Weibull}, @formula(Surv(time, status) ~ z), @formula(Surv(time, status) ~ w), dgh)
+    ctg = coeftable(mgh)
+    @test ctg.rownms == ["w [time-scale]", "z [hazard-level]"]
+    cig = confint(mgh)
+    @test cig.component == ["time-scale", "hazard-level"]
+    @test cig.term == ["w", "z"]
+    sg = repr(MIME"text/plain"(), mgh)
+    @test occursin("time-scale:", sg) && occursin("hazard-level:", sg)
+end
+
+@testitem "KaplanMeier show and RHS rejection" begin
+    using SurvivalModels, DataFrames, StatsModels
+
+    km = KaplanMeier([2.0, 3, 4, 5, 8, 3, 6], [1, 1, 0, 1, 0, 1, 1])
+    @test repr(MIME"text/plain"(), km) ==
+        "Kaplan-Meier survival estimate\n  n: 7, events: 5\n  median survival: 5.0\n"
+    @test repr(km) == "KaplanMeier(n=7)"
+
+    # Median is NA when the curve never reaches 0.5 (only one early event, rest censored).
+    km2 = KaplanMeier([1.0, 2, 3, 4], [1, 0, 0, 0])
+    @test occursin("median survival: NA", repr(MIME"text/plain"(), km2))
+
+    # Single-curve estimator: RHS variables are rejected rather than silently pooled.
+    df = DataFrame(time = [1.0, 2, 3, 4], status = Bool[1, 1, 0, 1], g = [:a, :a, :b, :b])
+    @test fit(KaplanMeier, @formula(Surv(time, status) ~ 1), df) isa KaplanMeier
+    @test_throws ArgumentError fit(KaplanMeier, @formula(Surv(time, status) ~ g), df)
+end


### PR DESCRIPTION
## Summary

Gives every model class a terse, faithful `show` plus an explicit `coeftable`/`confint` inference layer, and removes the non-idiomatic `summary(::Cox)`. Closes #78 and #79.

The design follows the S/R print-vs-summary convention: **`show` renders only stored state** (coefficients, baseline, fit statistics) and never computes covariance-derived quantities; **inference is requested explicitly** via `coeftable`/`confint`, which take a `level` keyword that a zero-argument display can't. `coeftable` returns a `StatsBase.CoefTable` (the ecosystem-standard, matching GLM.jl/MixedModels); `confint` returns a `DataFrame`.

## Cox

- Add `coef` / `coefnames` / `vcov`; `coeftable` (with `exp(coef)` and its confidence interval on the **hazard-ratio scale**, matching R's `summary(coxph)`) and `confint`.
- Terse `show` (method, n, events, loglik/AIC/BIC, coefficients). The O(n²) C-index is **no longer computed in `show`** — it stays available via `harrells_c`.
- **Remove `summary(::Cox)`** (#79): it overloaded `Base.summary`, whose contract is a one-line descriptor, with a full R-style table.

## GeneralHazardModel (#78)

Previously had no `show` at all — it fell back to Julia's default struct dump (every data matrix printed).

- Add `coefnames`, `coeftable`, `confint`, and a terse `show`.
- `coeftable`/`confint` cover the **covariate effects only**; baseline distribution parameters are shown by `show` as the fitted distribution, not tested — a null of zero is the question for a covariate effect but not for a baseline shape/scale.
- The GH model's **two coefficient sets are grouped and labelled by role** (`hazard-level` vs `time-scale`), since a covariate can enter both; PH/AFT/AH expose their single active block.

## KaplanMeier

- Add a `show` (n, events, median survival) replacing the struct dump.
- `fit` now **errors on right-hand-side variables** — `KaplanMeier` is a single-curve estimator, and silently returning a pooled curve for `~ g` is a footgun (R's `survfit` stratifies). Stratification is tracked in #83; this error is the interim guardrail it refers to.

## Shared / tests / docs

- `_coef_fmt`, `_ci_levstr`, `_hr_coeftable` factored into `utils.jl` so Cox and the parametric models build identical tables.
- Reference-string tests via `repr(MIME"text/plain"(), m)` for each model class (deterministic direct-construction / `StableRNG` fits), plus `coeftable`/`confint` structure and relationship checks.
- Docs updated: `cox.md` (`summary`→`coeftable`/`confint`), `fitting.md` (GHM `coeftable`/`confint`), `example.md` (each parametric class now displays its `show`).

734 tests pass; docs build locally.
