### PR TITLE
Automate registration and release v0.1.5

### DIFF
--- a/.github/workflows/JuliaRegisterChangelog.yml
+++ b/.github/workflows/JuliaRegisterChangelog.yml
@@ -1,0 +1,15 @@
+name: Auto-Changelog & Julia Register
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - Project.toml
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex180500/JuliaRegisterChangelog@latest
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SurvivalModels"
 uuid = "230d35e3-bb2c-48f4-adfc-0b42c4b39395"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Oskar Laverny <oskar.laverny@univ-amu.fr> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

- add the JuliaRegisterChangelog workflow
- bump the package patch version to v0.1.5
- generate release notes and trigger JuliaRegistrator when Project.toml changes

Closes #88