### PR TITLE
Show the actual output in the model docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SurvivalModels"
 uuid = "230d35e3-bb2c-48f4-adfc-0b42c4b39395"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Oskar Laverny <oskar.laverny@univ-amu.fr> and contributors"]
 
 [deps]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -13,3 +13,10 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Survival = "8a913413-2070-5976-9d4c-2b364fdc2f7f"
 SurvivalDistributions = "7121986e-ae89-4673-ae4e-1cb822919a18"
 SurvivalModels = "230d35e3-bb2c-48f4-adfc-0b42c4b39395"
+
+[compat]
+# The Cox page renders a `CoefTable` through Documenter, which uses the
+# `text/markdown` representation. Escaping of the `Pr(>|z|)` header's pipes
+# landed in 0.34.13 (JuliaStats/StatsBase.jl#1007); before that the table
+# renders as a mangled paragraph.
+StatsBase = "0.34.13"

--- a/src/Parametric/GeneralHazard.jl
+++ b/src/Parametric/GeneralHazard.jl
@@ -126,11 +126,53 @@ model = GeneralHazardModel(
 ```
 or fit it from data using the `fit` interface.
 
-Supported methods: 
+Supported methods:
 - `ProportionalHazard`: For PH models.
 - `AcceleratedFaillureTime`: For AFT models.
 - `AcceleratedHazard`: For AH models.
 - `GeneralHazard`: For full GH models.
+
+# Example: fitting and display
+
+A GH fit takes two formulas — the first supplies `X1` (the `hazard-level` block,
+`β`), the second `X2` (the `time-scale` block, `α`):
+
+```julia
+julia> using SurvivalModels, RDatasets, Distributions
+
+julia> ovarian = dataset("survival", "ovarian");
+
+julia> m = fit(GeneralHazard{Weibull},
+               @formula(Surv(FUTime, FUStat) ~ Age),
+               @formula(Surv(FUTime, FUStat) ~ ECOG_PS),
+               ovarian)
+General hazard model (Weibull baseline)
+  n: 26, events: 12
+  log-likelihood: -89.965, AIC: 187.93, BIC: 192.96
+  baseline: Weibull(1.6576, 216420.0)
+  coefficients:
+    time-scale:
+      ECOG_PS  -0.25149
+    hazard-level:
+      Age  0.16083
+```
+
+The display reports the fitted object only — baseline parameters, coefficients,
+and fit statistics. Inference lives in [`coeftable`](@ref) and
+[`confint`](@ref confint(::GeneralHazardModel)), which take a confidence level.
+(The large baseline scale above
+is not a display artefact: with 26 observations and 12 events the GH structure is
+only weakly identified on this dataset, and the scale trades off against the
+`hazard-level` effect of `Age`.)
+
+Outside of a REPL display — inside a container, say — the model prints in a
+one-line form:
+
+```julia
+julia> [m]
+1-element Vector{GeneralHazard{Weibull{Float64}}}:
+ General hazard{Weibull}(n=26)
+```
 """
 struct GeneralHazardModel{Method, B} <: StatsAPI.StatisticalModel
     T::Vector{Float64}
@@ -387,6 +429,31 @@ Wald confidence intervals for the covariate coefficients at confidence level
 `level`. Returns a `DataFrame` with columns `component` (the coefficient's role,
 `"hazard-level"` or `"time-scale"`), `term`, `lower`, and `upper`. Baseline
 distribution parameters are not included (see [`coeftable`](@ref)).
+
+The bounds are on the **coefficient** scale, unlike the `Lower`/`Upper` columns of
+[`coeftable`](@ref), which bracket `exp(coef)`.
+
+# Example
+
+For the model fitted in [`GeneralHazardModel`](@ref):
+
+```julia
+julia> confint(m)
+2×4 DataFrame
+ Row │ component     term     lower      upper
+     │ String        String   Float64    Float64
+─────┼────────────────────────────────────────────
+   1 │ time-scale    ECOG_PS  -2.03921   1.53622
+   2 │ hazard-level  Age       0.071952  0.249715
+
+julia> confint(m; level = 0.90)
+2×4 DataFrame
+ Row │ component     term     lower       upper
+     │ String        String   Float64     Float64
+─────┼─────────────────────────────────────────────
+   1 │ time-scale    ECOG_PS  -1.75179    1.24881
+   2 │ hazard-level  Age       0.0862418  0.235425
+```
 """
 function StatsAPI.confint(m::GeneralHazardModel; level::Real = 0.95)
     roles, terms, b, se = _gh_covariate_estimates(m)
@@ -405,6 +472,23 @@ rows are tagged with their role (`hazard-level` vs `time-scale`), since a
 covariate may enter both. Baseline distribution parameters are reported by `show`,
 not here: a null of zero is not the relevant hypothesis for a baseline
 shape/scale.
+
+Note that `Lower`/`Upper` bracket `exp(coef)`, not the coefficient itself; for
+intervals on the coefficient scale use [`confint`](@ref confint(::GeneralHazardModel)).
+
+# Example
+
+For the model fitted in [`GeneralHazardModel`](@ref):
+
+```julia
+julia> coeftable(m)
+─────────────────────────────────────────────────────────────────────────────────────────────
+                          Coef.  Std. Error      z  Pr(>|z|)  exp(coef)  Lower 95%  Upper 95%
+─────────────────────────────────────────────────────────────────────────────────────────────
+ECOG_PS [time-scale]  -0.251492   0.912117   -0.28    0.7828   0.777639   0.130132    4.64701
+Age [hazard-level]     0.160833   0.0453485   3.55    0.0004   1.17449    1.0746      1.28366
+─────────────────────────────────────────────────────────────────────────────────────────────
+```
 """
 function StatsAPI.coeftable(m::GeneralHazardModel; level::Real = 0.95)
     roles, terms, b, se = _gh_covariate_estimates(m)

--- a/src/Semiparametric/Cox.jl
+++ b/src/Semiparametric/Cox.jl
@@ -18,13 +18,33 @@ Returns:
 Example:
 
 ```julia
-ovarian = dataset("survival", "ovarian")
-ovarian.FUTime = Float64.(ovarian.FUTime) (Time column needs to be Float64 type)
-ovarian.FUStat = Bool.(ovarian.FUStat) (Status column needs to be Bool type)
-model = fit(Cox, @formula(Surv(FUTime, FUStat) ~ Age + ECOG_PS), ovarian)
+julia> using SurvivalModels, RDatasets
+
+julia> ovarian = dataset("survival", "ovarian");
+
+julia> model = fit(Cox, @formula(Surv(FUTime, FUStat) ~ Age + ECOG_PS), ovarian)
+Cox model (method: CoxDefault)
+  n: 26, events: 12
+  log-likelihood: -27.838, AIC: 59.675, BIC: 62.192
+  coefficients:
+    Age      0.1615
+    ECOG_PS  0.018662
 ```
 
-We need to add details about the different prediction types here. 
+The display reports the fitted object only — coefficients (log hazard ratios)
+and fit statistics. Inference lives in [`coeftable`](@ref coeftable(::Cox)) and
+[`confint`](@ref confint(::Cox)), which take a confidence level.
+
+Outside of a REPL display — inside a container, say — the model prints in a
+one-line form:
+
+```julia
+julia> [model]
+1-element Vector{Cox{SurvivalModels.CoxDefault}}:
+ Cox model (method: CoxDefault)
+```
+
+We need to add details about the different prediction types here.
 
 Types: 
 - Cox : the base abstract type
@@ -419,6 +439,23 @@ Wald coefficient table for a fitted Cox model: the coefficient (log hazard
 ratio), its standard error, the `z` statistic, the two-sided p-value, the hazard
 ratio `exp(coef)`, and the confidence interval for the hazard ratio at confidence
 level `level` (matching R's `summary(coxph)` convention).
+
+Note that `Lower`/`Upper` bracket `exp(coef)`, not the coefficient itself; for
+intervals on the coefficient scale use [`confint`](@ref confint(::Cox)).
+
+# Example
+
+For the model fitted in [`fit`](@ref SurvivalModels.CoxMethod):
+
+```julia
+julia> coeftable(model)
+───────────────────────────────────────────────────────────────────────────────
+             Coef.  Std. Error     z  Pr(>|z|)  exp(coef)  Lower 95%  Upper 95%
+───────────────────────────────────────────────────────────────────────────────
+Age      0.161501    0.0499226  3.24    0.0012    1.17527   1.06572     1.29608
+ECOG_PS  0.0186619   0.599085   0.03    0.9751    1.01884   0.314893    3.29645
+───────────────────────────────────────────────────────────────────────────────
+```
 """
 StatsAPI.coeftable(C::Cox; level::Real = 0.95) =
     _hr_coeftable(coef(C), stderror(C), coefnames(C); level = level)
@@ -429,6 +466,31 @@ StatsAPI.coeftable(C::Cox; level::Real = 0.95) =
 Wald confidence intervals for the coefficients (log-hazard-ratio scale) at
 confidence level `level`. Returns a `DataFrame` with columns `term`, `lower`,
 `upper`.
+
+The bounds are on the coefficient scale, unlike the `Lower`/`Upper` columns of
+[`coeftable`](@ref coeftable(::Cox)), which bracket the hazard ratio `exp(coef)`.
+
+# Example
+
+For the model fitted in [`fit`](@ref SurvivalModels.CoxMethod):
+
+```julia
+julia> confint(model)
+2×3 DataFrame
+ Row │ term     lower       upper
+     │ String   Float64     Float64
+─────┼───────────────────────────────
+   1 │ Age       0.0636547  0.259348
+   2 │ ECOG_PS  -1.15552    1.19285
+
+julia> confint(model; level = 0.90)
+2×3 DataFrame
+ Row │ term     lower       upper
+     │ String   Float64     Float64
+─────┼───────────────────────────────
+   1 │ Age       0.0793859  0.243617
+   2 │ ECOG_PS  -0.966745   1.00407
+```
 """
 function StatsAPI.confint(C::Cox; level::Real = 0.95)
     b = coef(C)


### PR DESCRIPTION
The docstrings for `Cox` and `GeneralHazardModel` described what `show`, `coeftable` and `confint` return without showing any of it. Several things about the output are hard to guess from prose: a GH fit's coefficients print grouped into `time-scale` and `hazard-level` blocks, a GH coefficient table tags its rows with those roles, and `confint` returns a `DataFrame` rather than a matrix.

This adds worked examples to both. Every line of output is pasted verbatim from a fit on `survival::ovarian` — nothing hand-written:

```julia
julia> m = fit(GeneralHazard{Weibull},
               @formula(Surv(FUTime, FUStat) ~ Age),
               @formula(Surv(FUTime, FUStat) ~ ECOG_PS),
               ovarian)
General hazard model (Weibull baseline)
  n: 26, events: 12
  log-likelihood: -89.965, AIC: 187.93, BIC: 192.96
  baseline: Weibull(1.6576, 216420.0)
  coefficients:
    time-scale:
      ECOG_PS  -0.25149
    hazard-level:
      Age  0.16083
```

Both `coeftable` docstrings now also state that `Lower`/`Upper` bracket `exp(coef)` while `confint` reports the coefficient scale — the two are consistent (`exp(-2.03921) = 0.130`), but easy to misread since neither table labels which scale it is on.

The blocks are fenced as ```` ```julia ````, not ```` ```jldoctest ````, so Documenter does not doctest them and the exact digits will not break a build if the optimizer output shifts.

## Two fixes found while writing the examples

- **Ambiguous `@ref` targets.** The bare ``[`confint`](@ref)`` links resolved to the `KaplanMeier` method rather than the model's own — verified in the rendered HTML, where they pointed at `#StatsAPI.confint-Tuple{KaplanMeier}`. Qualified with a signature; all of them now resolve to the intended method.
- **Invalid Julia in the `Cox` example.** Two lines had prose inside the code block (`ovarian.FUTime = Float64.(ovarian.FUTime) (Time column needs to be Float64 type)`). `fit(Cox, ...)` works on `ovarian` without either conversion, so both lines are dropped rather than reworded.

## StatsBase floor

The second commit pins `StatsBase = "0.34.13"` in `docs/Project.toml`. The Cox page renders a `CoefTable` through Documenter, which picks its `text/markdown` representation; before 0.34.13 that left the pipes in the `Pr(>|z|)` header unescaped, so the table degraded into a paragraph of pipes and en-dashes (fixed by JuliaStats/StatsBase.jl#1007). A docs build does not fail on a badly rendered table, so this is worth pinning rather than leaving to the resolver.

Docs build locally with zero errors, and the Cox coefficient table now renders as a real HTML table with `Pr(>|z|)` intact in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)